### PR TITLE
updates README with new link to the API Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pip install llm-guard
 **Examples**:
 
 - Get started with [ChatGPT and LLM Guard](./examples/openai_api.py).
-- Deploy LLM Guard as [API](https://llm-guard.com/usage/api/)
+- Deploy LLM Guard as [API](https://llm-guard.com/api/overview/)
 
 ## Supported scanners
 

--- a/llm_guard_api/README.md
+++ b/llm_guard_api/README.md
@@ -1,3 +1,3 @@
 # LLM Guard API
 
-[Documentation](https://llm-guard.com/usage/api/)
+[Documentation](https://llm-guard.com/api/overview/)


### PR DESCRIPTION
## Change Description

I noticed the link in the README file for the API Docs is broken (404), it is pointing to: https://llm-guard.com/usage/api/ 

<img width="1191" alt="image" src="https://github.com/protectai/llm-guard/assets/1958982/9e9079ba-83ef-47a5-851e-4337f4973193">

I changed it to the current URL of the API docs (https://llm-guard.com/api/overview/)

## Issue reference

N/A

## Checklist

- [x] I have reviewed the [contribution guidelines](../CONTRIBUTING.md)
- [_Not needed_] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
