### PR TITLE
docs(mkdocs): :lipstick: fix nested lists in mkdocs

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -20,7 +20,7 @@
 ###############
 MD004: false                  # Unordered list style
 MD007:
-  indent: 2                   # Unordered list indentation
+  indent: 4                   # Unordered list indentation
 MD010:
   code_blocks: false          # Ignore no-hard-tabs in cde blocks because that's how formatting for golang works
 MD013:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -241,8 +241,8 @@ _0.3.5 and 0.3.6 were skipped due to build issues._
 ### Changed
 - Added Swagger documentation on the [API](./api/overview.md) documentation page
 - Added `fail_fast` flag to stop the execution after the first failure
-  - Updated API and Playground to support `fail_fast` flag
-  - Clarified order of execution in the documentation
+    - Updated API and Playground to support `fail_fast` flag
+    - Clarified order of execution in the documentation
 - Added timeout configuration for API example
 - Better examples of `langchain` integration
 
@@ -354,24 +354,24 @@ _0.3.5 and 0.3.6 were skipped due to build issues._
 - [Documentation](./index.md)
 - Github Actions pipeline
 - Prompt scanners with tests:
-  - [Anonymize](./input_scanners/anonymize.md)
-  - [BanSubstrings](./input_scanners/ban_substrings.md)
-  - [BanTopics](./input_scanners/ban_topics.md)
-  - [Code](./input_scanners/code.md)
-  - [PromptInjection](./input_scanners/prompt_injection.md)
-  - [Sentiment](./input_scanners/sentiment.md)
-  - [TokenLimit](./input_scanners/token_limit.md)
-  - [Toxicity](./input_scanners/toxicity.md)
+    - [Anonymize](./input_scanners/anonymize.md)
+    - [BanSubstrings](./input_scanners/ban_substrings.md)
+    - [BanTopics](./input_scanners/ban_topics.md)
+    - [Code](./input_scanners/code.md)
+    - [PromptInjection](./input_scanners/prompt_injection.md)
+    - [Sentiment](./input_scanners/sentiment.md)
+    - [TokenLimit](./input_scanners/token_limit.md)
+    - [Toxicity](./input_scanners/toxicity.md)
 - Output scanners with tests:
-  - [BanSubstrings](./output_scanners/ban_substrings.md)
-  - [BanTopics](./output_scanners/ban_topics.md)
-  - [Code](./output_scanners/code.md)
-  - [Deanonymize](./output_scanners/deanonymize.md)
-  - [NoRefusal](./output_scanners/no_refusal.md)
-  - [Regex](./output_scanners/regex.md)
-  - [Relevance](./output_scanners/relevance.md)
-  - [Sensitive](./output_scanners/sensitive.md)
-  - [Toxicity](./output_scanners/toxicity.md)
+    - [BanSubstrings](./output_scanners/ban_substrings.md)
+    - [BanTopics](./output_scanners/ban_topics.md)
+    - [Code](./output_scanners/code.md)
+    - [Deanonymize](./output_scanners/deanonymize.md)
+    - [NoRefusal](./output_scanners/no_refusal.md)
+    - [Regex](./output_scanners/regex.md)
+    - [Relevance](./output_scanners/relevance.md)
+    - [Sensitive](./output_scanners/sensitive.md)
+    - [Toxicity](./output_scanners/toxicity.md)
 
 [Unreleased]: https://github.com/protectai/llm-guard/commits/main
 [0.3.12]: https://github.com/protectai/llm-guard/releases/tag/v0.3.12

--- a/docs/input_scanners/anonymize.md
+++ b/docs/input_scanners/anonymize.md
@@ -18,33 +18,33 @@ Some model providers may train their models on your requests, which can be a pri
 ## PII entities
 
 - **Credit Cards**: Formats mentioned in [Wikipedia](https://en.wikipedia.org/wiki/Payment_card_number).
-  - `4111111111111111`
-  - `378282246310005` (American Express)
-  - `30569309025904` (Diners Club)
+    - `4111111111111111`
+    - `378282246310005` (American Express)
+    - `30569309025904` (Diners Club)
 - **Person**: A full person name, which can include first names, middle names or initials, and last names.
-  - `John Doe`
+    - `John Doe`
 - **PHONE_NUMBER**:
-  - `5555551234`
+    - `5555551234`
 - **URL**: A URL (Uniform Resource Locator), unique identifier used to locate a resource on the Internet.
-  - `https://protectai.com/`
+    - `https://protectai.com/`
 - **E-mail Addresses**: Standard email formats.
-  - `john.doe@protectai.com`
-  - `john.doe[AT]protectai[DOT]com`
-  - `john.doe[AT]protectai.com`
-  - `john.doe@protectai[DOT]com`
+    - `john.doe@protectai.com`
+    - `john.doe[AT]protectai[DOT]com`
+    - `john.doe[AT]protectai.com`
+    - `john.doe@protectai[DOT]com`
 - **IPs**: An Internet Protocol (IP) address (either IPv4 or IPv6).
-  - `192.168.1.1` (IPv4)
-  - `2001:db8:3333:4444:5555:6666:7777:8888` (IPv6)
+    - `192.168.1.1` (IPv4)
+    - `2001:db8:3333:4444:5555:6666:7777:8888` (IPv6)
 - **UUID**:
-  - `550e8400-e29b-41d4-a716-446655440000`
+    - `550e8400-e29b-41d4-a716-446655440000`
 - **US Social Security Number (SSN)**:
-  - `111-22-3333`
+    - `111-22-3333`
 - **Crypto wallet number**: Currently only Bitcoin address is supported.
-  - `1Lbcfr7sAHTD9CgdQo3HTMTkV8LK4ZnX71`
+    - `1Lbcfr7sAHTD9CgdQo3HTMTkV8LK4ZnX71`
 - **IBAN Code**: The International Bank Account Number (IBAN) is an internationally agreed system of identifying bank
   accounts across national borders to facilitate the communication and processing of cross border transactions with a
   reduced risk of transcription errors.
-  - `DE89370400440532013000`
+    - `DE89370400440532013000`
 
 ## Features
 
@@ -53,19 +53,19 @@ Some model providers may train their models on your requests, which can be a pri
 - **Enhanced Detection**: Beyond Presidio Analyzer's capabilities, the scanner recognizes specific patterns like Email,
   US SSN, UUID, and more.
 - **Entities support**:
-  - Peek at
+    - Peek at
     our [default entities](https://github.com/protectai/llm-guard/blob/main/llm_guard/input_scanners/anonymize.py#L26-L40).
-  - View
+    - View
     the [Presidio's supported entities](https://microsoft.github.io/presidio/supported_entities/#list-of-supported-entities).
-  - And, we've
+    - And, we've
     got [custom regex patterns](https://github.com/protectai/llm-guard/blob/main/llm_guard/resources/sensisitive_patterns.json)
     too!
 - **Tailored recognizers**:
-  - Balance speed vs. accuracy of the recognizers.
-  - **Top Pick: [dslim/bert-base-NER](https://huggingface.co/dslim/bert-base-NER)**
-  - Alternative with more parameters: [dslim/bert-large-NER](https://huggingface.co/dslim/bert-large-NER).
-  - Chinese recognizer: [gyr66/bert-base-chinese-finetuned-ner](https://huggingface.co/gyr66/bert-base-chinese-finetuned-ner).
-  - Good models from AI4Privacy: [Isotonic/distilbert_finetuned_ai4privacy_v2](https://huggingface.co/Isotonic/distilbert_finetuned_ai4privacy_v2) and [Isotonic/deberta-v3-base_finetuned_ai4privacy_v2](https://huggingface.co/Isotonic/deberta-v3-base_finetuned_ai4privacy_v2).
+    - Balance speed vs. accuracy of the recognizers.
+    - **Top Pick: [dslim/bert-base-NER](https://huggingface.co/dslim/bert-base-NER)**
+    - Alternative with more parameters: [dslim/bert-large-NER](https://huggingface.co/dslim/bert-large-NER).
+    - Chinese recognizer: [gyr66/bert-base-chinese-finetuned-ner](https://huggingface.co/gyr66/bert-base-chinese-finetuned-ner).
+    - Good models from AI4Privacy: [Isotonic/distilbert_finetuned_ai4privacy_v2](https://huggingface.co/Isotonic/distilbert_finetuned_ai4privacy_v2) and [Isotonic/deberta-v3-base_finetuned_ai4privacy_v2](https://huggingface.co/Isotonic/deberta-v3-base_finetuned_ai4privacy_v2).
 - **Support of multiple languages**: The scanner can detect PII in English and Chinese.
 
 !!! info

--- a/docs/input_scanners/ban_code.md
+++ b/docs/input_scanners/ban_code.md
@@ -1,6 +1,6 @@
-# Code Scanner
+# Ban Code Scanner
 
-This scanner is designed to detect and ban code in the prompt.
+The `BanCode` scanner is designed to detect and ban code in the prompt.
 
 ## Attack scenario
 


### PR DESCRIPTION
## Change Description

While browsing the docs, I noticed the nested lists were not showing up correctly.
<img width="993" alt="Screenshot 2024-04-25 at 2 59 41 PM" src="https://github.com/protectai/llm-guard/assets/8380706/78438e3d-3b87-43b0-b34e-27a91b68b187">

To get nested supports, per this https://yakworks.github.io/docmark/cheat-sheet/ and testing, it needs to be 4 spaces, not 2.

<img width="931" alt="Screenshot 2024-04-25 at 3 06 05 PM" src="https://github.com/protectai/llm-guard/assets/8380706/33d75e7d-9976-4dec-8c92-68fb3b816c86">

- [x] update rules for markdownlint
- [x] update markdown files
- [x] test/view in mkdocs
- [x] fix other misc things

## Checklist

- [x] I have reviewed the [contribution guidelines](../CONTRIBUTING.md)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
