### PR TITLE
ci: improve tests readability

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,4 +43,4 @@ jobs:
           python -m pip install ".[dev]"
       - name: Test with pytest
         run: |
-          python -m pytest --exitfirst --verbose --failed-first --cov=.
+          python -m pytest --exitfirst --verbose --failed-first --cov=. --color=yes --code-highlight=yes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ classifiers = [
 requires-python = ">=3.9,<3.13"
 
 dependencies = [
-  "bc-detect-secrets==1.5.13",
-  "faker>=22,<26",
+  "bc-detect-secrets==1.5.14",
+  "faker>=26.0.0,<27",
   "fuzzysearch>=0.7,<0.9",
   "json-repair>=0.25.2,<0.26",
   "nltk>=3.8,<4",


### PR DESCRIPTION
## Change Description

The intent was to understand why faker pr was failing, but 
1) adding colorized output to improve readability for pytests in the github actions log.
2) investigate why tests are failing in the two dependabot pr's. 

https://github.com/protectai/llm-guard/pull/159 was failing due to a huggingface timeout
https://github.com/protectai/llm-guard/actions/runs/9841118912/job/27166982978 is failing due to some strange npm issue maybe related to the github cache?

Either way both dependencies are passing in this PR.

Before --color support
<img width="1080" alt="Screenshot 2024-07-08 at 7 57 06 PM" src="https://github.com/protectai/llm-guard/assets/8380706/1c09b18d-9052-4ccf-aa42-55ea2eaf334d">

After --color support
<img width="1083" alt="Screenshot 2024-07-08 at 7 55 45 PM" src="https://github.com/protectai/llm-guard/assets/8380706/40f6342d-01f6-4f24-8b5e-b20262ad1482">



## Issue reference

This PR fixes issue #XX

## Checklist

- [x] I have reviewed the [contribution guidelines](../CONTRIBUTING.md)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
