### PR TITLE
Remove dependency on deprecated oldest-supported-numpy

### DIFF
--- a/llm_guard_api/pyproject.toml
+++ b/llm_guard_api/pyproject.toml
@@ -33,8 +33,7 @@ dependencies = [
     "opentelemetry-exporter-prometheus==0.47b0",
     "opentelemetry-sdk-extension-aws==2.0.2",
     "opentelemetry-propagator-aws-xray==1.0.2",
-    "psutil>=5.9",
-    "oldest-supported-numpy"
+    "psutil>=5.9"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,7 @@ dependencies = [
   "tiktoken>=0.5,<0.8",
   "torch>=2.4.0",
   "transformers>=4.43.4",
-  "structlog>=24",
-  "oldest-supported-numpy"
+  "structlog>=24"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Change Description

Remove dependency on the deprecated oldest-supported-numpy. They state that it is not necessary to use that package anymore since numpy 1.25. To my understanding, the dependency would only be required as build-time-dependency and not as a runtime dependency.

References:
* https://github.com/scipy/oldest-supported-numpy
* https://numpy.org/doc/2.1/dev/depending_on_numpy.html#build-time-dependency

## Issue reference

The dependency breaks resolution for artifacts requiring a higher version of numpy:

`
  File "/opt/python/versions/3.11.10/lib/python3.11/site-packages/resolvelib/resolvers.py", line 318, in _backjump
    raise ResolutionImpossible(causes)
resolvelib.resolvers.ResolutionImpossible: [RequirementInformation(requirement=<Requirement('numpy==1.26.4; python_version >= "3.11" and python_version < "3.12"')>, parent=None), ..., RequirementInformation(requirement=<Requirement('numpy==1.23.2; python_version == "3.11" and platform_python_implementation != "PyPy"')>, parent=Candidate(name='oldest-supported-numpy', version=<Version('2022.11.19')>, extras=set()))]
`

## Checklist

- [/] I have reviewed the [contribution guidelines](../CONTRIBUTING.md)
- [/] My code includes unit tests
- [/] All unit tests and lint checks pass locally
- [/] My PR contains documentation updates / additions if required
