### PR TITLE
ci: pin 3rd party actions to specific revisions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/init@4c50b6f6fd9dc6fe03111c2d045c8be2a724cce1 # v3.28.11
         with:
           languages: python
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@4c50b6f6fd9dc6fe03111c2d045c8be2a724cce1 # v3.28.11

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,4 +29,4 @@ jobs:
           python -m pip install ".[onnxruntime]"
 
       - name: Run pre-commit hooks
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1


### PR DESCRIPTION
## Change Description

This PR fixes all used 3rd party actions (except GitHub owned actions in the `actions` namespace) to a specific Git revision to prevent supply-chain attacks where Git tags are overwritten with a malicious revision.

## Issue reference

_None_

## Checklist

- [x] I have reviewed the [contribution guidelines](../CONTRIBUTING.md)
- [x] ~~My code includes unit tests~~ (does not apply)
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
