### PR TITLE
Fix versions of pinned 3rd party actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      - uses: github/codeql-action/init@4c50b6f6fd9dc6fe03111c2d045c8be2a724cce1 # v3.28.11
+      - uses: github/codeql-action/init@v3
         with:
           languages: python
-      - uses: github/codeql-action/analyze@4c50b6f6fd9dc6fe03111c2d045c8be2a724cce1 # v3.28.11
+      - uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/init@6bb031afdd8eb862ea3fc1848194185e076637e5 # v3.28.11
         with:
           languages: python
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@6bb031afdd8eb862ea3fc1848194185e076637e5 # v3.28.11

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,4 +29,4 @@ jobs:
           python -m pip install ".[onnxruntime]"
 
       - name: Run pre-commit hooks
-        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        uses: pre-commit/action@v3.0.1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,4 +29,4 @@ jobs:
           python -m pip install ".[onnxruntime]"
 
       - name: Run pre-commit hooks
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1


### PR DESCRIPTION
## Change Description

- **Revert "ci: pin 3rd party actions to specific revisions"**
- **Update CI action versions to point to signed commits where possible**

The script I used in #218 to determine the Git revisions for the 3rd party apps did not take annotated tags into account. This means, the used commits are correct but point to the revisions of the non-annotated tags.

