### PR TITLE
 Fix broken documentation link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ we would love to have you as part of our community.
 - Give us a ⭐️ github star ⭐️ on the top of this page to support what we're doing,
   it means a lot for open source projects!
 - Read our
-  [docs](https://llm-guard.com/)
+  [docs](https://protectai.github.io/llm-guard/)
   for more info about how to use and customize LLM Guard, and for step-by-step tutorials.
 - Post a [Github
   Issue](https://github.com/protectai/llm-guard/issues) to submit a bug report, feature request, or suggest an improvement.


### PR DESCRIPTION
## Change Description

This PR updates the link to the documentation in the README.md file.  
The previous link (https://llm-guard.com/) was broken and led to a non-existent page.  
It has been replaced with the correct link: https://protectai.github.io/llm-guard/.

## Issue reference

This PR fixes issue #253 

## Checklist

- [x] I have reviewed the [contribution guidelines](../CONTRIBUTING.md)
- [ ] ~~My code includes unit tests~~
- [ ] ~~All unit tests and lint checks pass locally~~
- [x] My PR contains documentation updates / additions if required