### PR TITLE
Fix: Avoid unnecessary zh model download when using En lang (#227)

### DIFF
--- a/llm_guard/input_scanners/anonymize.py
+++ b/llm_guard/input_scanners/anonymize.py
@@ -122,7 +122,7 @@ class Anonymize(Scanner):
             recognizer=transformers_recognizer,
             regex_groups=get_regex_patterns(regex_patterns),
             custom_names=hidden_names,
-            supported_languages=ALL_SUPPORTED_LANGUAGES,
+            supported_languages=list(set(["en", language])),
         )
 
     def _remove_conflicts_and_get_text_manipulation_data(

--- a/llm_guard/output_scanners/sensitive.py
+++ b/llm_guard/output_scanners/sensitive.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from presidio_anonymizer import AnonymizerEngine
 
+from llm_guard.exception import LLMGuardValidationError
 from llm_guard.input_scanners.anonymize import (
     ALL_SUPPORTED_LANGUAGES,
     DEFAULT_ENTITY_TYPES,
@@ -42,6 +43,7 @@ class Sensitive(Scanner):
         recognizer_conf: NERConfig | None = None,
         threshold: float = 0.5,
         use_onnx: bool = False,
+        language: str = "en",
     ) -> None:
         """
         Initializes an instance of the Sensitive class.
@@ -55,6 +57,11 @@ class Sensitive(Scanner):
            threshold (float): Acceptance threshold. Default is 0.
            use_onnx (bool): Use ONNX model for inference. Default is False.
         """
+        if language not in ALL_SUPPORTED_LANGUAGES:
+            raise LLMGuardValidationError(
+                f"Language must be in the list of allowed: {ALL_SUPPORTED_LANGUAGES}"
+            )
+
         if not entity_types:
             LOGGER.debug(
                 "No entity types provided, using default", default_entity_types=DEFAULT_ENTITY_TYPES
@@ -74,7 +81,10 @@ class Sensitive(Scanner):
             use_onnx=use_onnx,
         )
         self._analyzer = get_analyzer(
-            transformers_recognizer, get_regex_patterns(regex_patterns), [], ALL_SUPPORTED_LANGUAGES
+            transformers_recognizer,
+            get_regex_patterns(regex_patterns),
+            [],
+            list(set(["en", language])),
         )
         self._anonymizer = AnonymizerEngine()
 


### PR DESCRIPTION
## Change Description

Fixes a bug where the Anonymize scanner attempted to download the `zh_core_web_sm` model even when the configured language was `"en"`. 

The issue was caused by the scanner using a global list of supported languages (`ALL_SUPPORTED_LANGUAGES`) instead of the specific `language` parameter passed in the config. This PR updates the logic to ensure only the specified language model is used.

Same also for the Sensitive output scanner, it download both en and zh core_web models . I added default parameter `language: str = "en",` just like the anonymize and used the same logic


## Issue reference

This PR fixes issue #227

## Checklist

- [x] I have reviewed the [contribution guidelines](../CONTRIBUTING.md)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
