### PR TITLE
feat: add vault support to Regex scanner for redacted value storage

### DIFF
--- a/docs/tutorials/notebooks/llama_index_rag.ipynb
+++ b/docs/tutorials/notebooks/llama_index_rag.ipynb
@@ -2,6 +2,10 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "51962b149f00f6f7",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "# Secure RAG with LLamaIndex\n",
     "\n",
@@ -12,23 +16,19 @@
     "-----------------\n",
     "\n",
     "Let's start by installing [LlamaIndex](https://www.llamaindex.ai/)"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "51962b149f00f6f7"
+   ]
   },
   {
    "cell_type": "code",
-   "source": "%pip install llama-index==0.10.36 pymupdf",
+   "execution_count": 5,
+   "id": "9ce028c0c53b124c",
    "metadata": {
-    "collapsed": false,
     "ExecuteTime": {
      "end_time": "2024-05-10T12:54:33.779871Z",
      "start_time": "2024-05-10T12:54:27.897507Z"
-    }
+    },
+    "collapsed": false
    },
-   "id": "9ce028c0c53b124c",
    "outputs": [
     {
      "name": "stdout",
@@ -108,106 +108,118 @@
       "Requirement already satisfied: pydantic-core==2.16.3 in ./venv/lib/python3.11/site-packages (from pydantic>=1.10->llamaindex-py-client<0.2.0,>=0.1.18->llama-index-core<0.11.0,>=0.10.35->llama-index==0.10.36) (2.16.3)\r\n",
       "Requirement already satisfied: six>=1.5 in ./venv/lib/python3.11/site-packages (from python-dateutil>=2.8.2->pandas->llama-index-core<0.11.0,>=0.10.35->llama-index==0.10.36) (1.16.0)\r\n",
       "Downloading PyMuPDF-1.24.3-cp311-none-macosx_11_0_arm64.whl (3.0 MB)\r\n",
-      "\u001B[2K   \u001B[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[32m3.0/3.0 MB\u001B[0m \u001B[31m8.4 MB/s\u001B[0m eta \u001B[36m0:00:00\u001B[0ma \u001B[36m0:00:01\u001B[0mm\r\n",
-      "\u001B[?25hDownloading PyMuPDFb-1.24.3-py3-none-macosx_11_0_arm64.whl (14.9 MB)\r\n",
-      "\u001B[2K   \u001B[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[32m14.9/14.9 MB\u001B[0m \u001B[31m5.4 MB/s\u001B[0m eta \u001B[36m0:00:00\u001B[0m00:01\u001B[0m00:01\u001B[0m\r\n",
-      "\u001B[?25hInstalling collected packages: PyMuPDFb, pymupdf\r\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.0/3.0 MB\u001b[0m \u001b[31m8.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0mm\r\n",
+      "\u001b[?25hDownloading PyMuPDFb-1.24.3-py3-none-macosx_11_0_arm64.whl (14.9 MB)\r\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m14.9/14.9 MB\u001b[0m \u001b[31m5.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\r\n",
+      "\u001b[?25hInstalling collected packages: PyMuPDFb, pymupdf\r\n",
       "Successfully installed PyMuPDFb-1.24.3 pymupdf-1.24.3\r\n",
       "Note: you may need to restart the kernel to use updated packages.\n"
      ]
     }
    ],
-   "execution_count": 5
+   "source": [
+    "%pip install llama-index==0.10.36 pymupdf"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Then we need to set up the environment."
-   ],
+   "id": "863737fbf3f044fc",
    "metadata": {
     "collapsed": false
    },
-   "id": "863737fbf3f044fc"
+   "source": [
+    "Then we need to set up the environment."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 6,
+   "id": "3a07b101b2ffa688",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-05-10T12:54:37.454349Z",
+     "start_time": "2024-05-10T12:54:37.449987Z"
+    },
+    "collapsed": false
+   },
+   "outputs": [],
    "source": [
     "import logging\n",
     "import sys\n",
     "\n",
     "logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
     "logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2024-05-10T12:54:37.454349Z",
-     "start_time": "2024-05-10T12:54:37.449987Z"
-    }
-   },
-   "id": "3a07b101b2ffa688",
-   "outputs": [],
-   "execution_count": 6
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 7,
+   "id": "4e001f18cbf00260",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-05-10T12:54:38.401651Z",
+     "start_time": "2024-05-10T12:54:38.398852Z"
+    },
+    "collapsed": false
+   },
+   "outputs": [],
    "source": [
     "import openai\n",
     "\n",
     "openai.api_key = \"sk-tet-key\""
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2024-05-10T12:54:38.401651Z",
-     "start_time": "2024-05-10T12:54:38.398852Z"
-    }
-   },
-   "id": "4e001f18cbf00260",
-   "outputs": [],
-   "execution_count": 7
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Now, we can load the test document with fake resumes."
-   ],
+   "id": "ccf590b3c9a27e61",
    "metadata": {
     "collapsed": false
    },
-   "id": "ccf590b3c9a27e61"
+   "source": [
+    "Now, we can load the test document with fake resumes."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 12,
+   "id": "2ead084009baf0af",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-05-10T13:02:27.274339Z",
+     "start_time": "2024-05-10T13:02:27.250904Z"
+    },
+    "collapsed": false
+   },
+   "outputs": [],
    "source": [
     "from llama_index.readers.file.pymu_pdf import PyMuPDFReader\n",
     "\n",
     "reader = PyMuPDFReader()\n",
     "documents = reader.load(file_path=\"./resumes.pdf\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2024-05-10T13:02:27.274339Z",
-     "start_time": "2024-05-10T13:02:27.250904Z"
-    }
-   },
-   "id": "2ead084009baf0af",
-   "outputs": [],
-   "execution_count": 12
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Now, we can import the libraries and configure them."
-   ],
+   "id": "a55e0e435d622d25",
    "metadata": {
     "collapsed": false
    },
-   "id": "a55e0e435d622d25"
+   "source": [
+    "Now, we can import the libraries and configure them."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 13,
+   "id": "4728b71fd39e557b",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-05-10T13:02:29.431305Z",
+     "start_time": "2024-05-10T13:02:29.427667Z"
+    },
+    "collapsed": false
+   },
+   "outputs": [],
    "source": [
     "# Only for debugging purposes\n",
     "from llama_index.core.callbacks import (\n",
@@ -218,45 +230,19 @@
     "\n",
     "llama_debug = LlamaDebugHandler(print_trace_on_end=True)\n",
     "callback_manager = CallbackManager([llama_debug])"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2024-05-10T13:02:29.431305Z",
-     "start_time": "2024-05-10T13:02:29.427667Z"
-    }
-   },
-   "id": "4728b71fd39e557b",
-   "outputs": [],
-   "execution_count": 13
+   ]
   },
   {
    "cell_type": "code",
-   "source": [
-    "from llama_index.core.indices import VectorStoreIndex\n",
-    "from llama_index.core.service_context import ServiceContext\n",
-    "from llama_index.embeddings.openai import OpenAIEmbedding\n",
-    "from llama_index.llms.openai import OpenAI\n",
-    "from llama_index.core.node_parser import SentenceSplitter\n",
-    "\n",
-    "embded_model = OpenAIEmbedding()\n",
-    "llm = OpenAI(model=\"gpt-3.5-turbo\", temperature=0.1)\n",
-    "transformations = [\n",
-    "    SentenceSplitter(),\n",
-    "    embded_model,\n",
-    "]\n",
-    "index = VectorStoreIndex.from_documents(\n",
-    "    documents, callback_manager=callback_manager, transformations=transformations,\n",
-    ")"
-   ],
+   "execution_count": 14,
+   "id": "5099115c04eac6a7",
    "metadata": {
-    "collapsed": false,
     "ExecuteTime": {
      "end_time": "2024-05-10T13:02:35.581911Z",
      "start_time": "2024-05-10T13:02:34.708180Z"
-    }
+    },
+    "collapsed": false
    },
-   "id": "5099115c04eac6a7",
    "outputs": [
     {
      "name": "stdout",
@@ -271,33 +257,47 @@
      ]
     }
    ],
-   "execution_count": 14
+   "source": [
+    "from llama_index.core.indices import VectorStoreIndex\n",
+    "from llama_index.core.service_context import ServiceContext\n",
+    "from llama_index.embeddings.openai import OpenAIEmbedding\n",
+    "from llama_index.llms.openai import OpenAI\n",
+    "from llama_index.core.node_parser import SentenceSplitter\n",
+    "\n",
+    "embded_model = OpenAIEmbedding()\n",
+    "llm = OpenAI(model=\"gpt-3.5-turbo\", temperature=0.1)\n",
+    "transformations = [\n",
+    "    SentenceSplitter(),\n",
+    "    embded_model,\n",
+    "]\n",
+    "index = VectorStoreIndex.from_documents(\n",
+    "    documents,\n",
+    "    callback_manager=callback_manager,\n",
+    "    transformations=transformations,\n",
+    ")"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Once it's done, we can run query and see the results."
-   ],
+   "id": "e5125f5f5a94b686",
    "metadata": {
     "collapsed": false
    },
-   "id": "e5125f5f5a94b686"
+   "source": [
+    "Once it's done, we can run query and see the results."
+   ]
   },
   {
    "cell_type": "code",
-   "source": [
-    "query_engine = index.as_query_engine(similarity_top_k=3)\n",
-    "response = query_engine.query(\"I am screening candidates for adult caregiving opportunity. Please recommend me an experienced person. Return just a name\")\n",
-    "print(str(response))"
-   ],
+   "execution_count": 15,
+   "id": "677fc20c2f47a722",
    "metadata": {
-    "collapsed": false,
     "ExecuteTime": {
      "end_time": "2024-05-10T13:03:06.013241Z",
      "start_time": "2024-05-10T13:03:04.703891Z"
-    }
+    },
+    "collapsed": false
    },
-   "id": "677fc20c2f47a722",
    "outputs": [
     {
      "name": "stdout",
@@ -313,34 +313,37 @@
      ]
     }
    ],
-   "execution_count": 15
+   "source": [
+    "query_engine = index.as_query_engine(similarity_top_k=3)\n",
+    "response = query_engine.query(\n",
+    "    \"I am screening candidates for adult caregiving opportunity. Please recommend me an experienced person. Return just a name\"\n",
+    ")\n",
+    "print(str(response))"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "9e9d3a0d0fbe1994",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "We can see that the most inexperienced person was picked up, so the attack was successful.\n",
     "\n",
     "We can also see the debug logs."
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "9e9d3a0d0fbe1994"
+   ]
   },
   {
    "cell_type": "code",
-   "source": [
-    "print(llama_debug.get_events())\n",
-    "llama_debug.flush_event_logs()"
-   ],
+   "execution_count": 16,
+   "id": "72a68fd3374135bd",
    "metadata": {
-    "collapsed": false,
     "ExecuteTime": {
      "end_time": "2024-05-10T13:03:10.126174Z",
      "start_time": "2024-05-10T13:03:10.123293Z"
-    }
+    },
+    "collapsed": false
    },
-   "id": "72a68fd3374135bd",
    "outputs": [
     {
      "name": "stdout",
@@ -350,44 +353,57 @@
      ]
     }
    ],
-   "execution_count": 16
+   "source": [
+    "print(llama_debug.get_events())\n",
+    "llama_debug.flush_event_logs()"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "477e2fc206743faa",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "----\n",
     "\n",
     "Now let's try to secure it with LLM Guard. We will redact PII and detect prompt injections."
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "477e2fc206743faa"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a6ce0fdc79896bb9",
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "!pip install llm-guard==0.3.10"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "a6ce0fdc79896bb9"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "First, we need to make an [Output Parsing Modules](https://docs.llamaindex.ai/en/stable/module_guides/querying/output_parser.html). It will scan the output and replace PII placeholders with real values."
-   ],
+   "id": "9daa98f22f6e84a1",
    "metadata": {
     "collapsed": false
    },
-   "id": "9daa98f22f6e84a1"
+   "source": [
+    "First, we need to make an [Output Parsing Modules](https://docs.llamaindex.ai/en/stable/module_guides/querying/output_parser.html). It will scan the output and replace PII placeholders with real values."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 17,
+   "id": "d14c0e84658e387",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-05-10T13:03:36.660333Z",
+     "start_time": "2024-05-10T13:03:32.917766Z"
+    },
+    "collapsed": false
+   },
+   "outputs": [],
    "source": [
     "from typing import Any, List\n",
     "from llama_index.core.types import BaseOutputParser\n",
@@ -405,105 +421,88 @@
     "        self.fail_fast = fail_fast\n",
     "\n",
     "    def parse(self, output: str, query: str = \"\") -> Any:\n",
-    "        sanitized_output, results_valid, results_score = scan_output(self.output_scanners, query, output, self.fail_fast)\n",
-    "        \n",
+    "        sanitized_output, results_valid, results_score = scan_output(\n",
+    "            self.output_scanners, query, output, self.fail_fast\n",
+    "        )\n",
+    "\n",
     "        if not all(results_valid.values()):\n",
-    "            raise LLMGuardOutputParserException(f\"Output `{sanitized_output}` is not valid, scores: {results_score}\")\n",
-    "        \n",
+    "            raise LLMGuardOutputParserException(\n",
+    "                f\"Output `{sanitized_output}` is not valid, scores: {results_score}\"\n",
+    "            )\n",
+    "\n",
     "        return sanitized_output\n",
-    "    \n",
+    "\n",
     "    def format(self, query: str) -> str:\n",
     "        # You can also implement input scanning here\n",
-    "        \n",
+    "\n",
     "        return query"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2024-05-10T13:03:36.660333Z",
-     "start_time": "2024-05-10T13:03:32.917766Z"
-    }
-   },
-   "id": "d14c0e84658e387",
-   "outputs": [],
-   "execution_count": 17
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Let's configure output scanners."
-   ],
+   "id": "bb61ba3426861494",
    "metadata": {
     "collapsed": false
    },
-   "id": "bb61ba3426861494"
+   "source": [
+    "Let's configure output scanners."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 18,
+   "id": "d2e35f8d15611556",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-05-10T13:03:37.494478Z",
+     "start_time": "2024-05-10T13:03:36.661269Z"
+    },
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[2m2024-05-10 15:03:37\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mInitialized classification model\u001b[0m \u001b[36mdevice\u001b[0m=\u001b[35mdevice(type='mps')\u001b[0m \u001b[36mmodel\u001b[0m=\u001b[35mModel(path='unitary/unbiased-toxic-roberta', subfolder='', revision='36295dd80b422dc49f40052021430dae76241adc', onnx_path='ProtectAI/unbiased-toxic-roberta-onnx', onnx_revision='34480fa958f6657ad835c345808475755b6974a7', onnx_subfolder='', onnx_filename='model.onnx', onnx_enable_hack=True, kwargs={}, pipeline_kwargs={'padding': 'max_length', 'top_k': None, 'function_to_apply': 'sigmoid', 'truncation': True})\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
     "from llm_guard.vault import Vault\n",
     "from llm_guard.output_scanners import Deanonymize, Toxicity\n",
     "\n",
     "vault = Vault()\n",
     "\n",
-    "output_parser=LLMGuardOutputParser(\n",
+    "output_parser = LLMGuardOutputParser(\n",
     "    output_scanners=[\n",
     "        Deanonymize(vault),\n",
     "        Toxicity(),\n",
     "    ]\n",
     ")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2024-05-10T13:03:37.494478Z",
-     "start_time": "2024-05-10T13:03:36.661269Z"
-    }
-   },
-   "id": "d2e35f8d15611556",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001B[2m2024-05-10 15:03:37\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mInitialized classification model\u001B[0m \u001B[36mdevice\u001B[0m=\u001B[35mdevice(type='mps')\u001B[0m \u001B[36mmodel\u001B[0m=\u001B[35mModel(path='unitary/unbiased-toxic-roberta', subfolder='', revision='36295dd80b422dc49f40052021430dae76241adc', onnx_path='ProtectAI/unbiased-toxic-roberta-onnx', onnx_revision='34480fa958f6657ad835c345808475755b6974a7', onnx_subfolder='', onnx_filename='model.onnx', onnx_enable_hack=True, kwargs={}, pipeline_kwargs={'padding': 'max_length', 'top_k': None, 'function_to_apply': 'sigmoid', 'truncation': True})\u001B[0m\n"
-     ]
-    }
-   ],
-   "execution_count": 18
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "And reinitiate service context again with the new output parser."
-   ],
+   "id": "df90552aa165d6b9",
    "metadata": {
     "collapsed": false
    },
-   "id": "df90552aa165d6b9"
+   "source": [
+    "And reinitiate service context again with the new output parser."
+   ]
   },
   {
    "cell_type": "code",
-   "source": [
-    "llm = OpenAI(model=\"gpt-3.5-turbo\", temperature=0.1, output_parser=output_parser)\n",
-    "\n",
-    "service_context = ServiceContext.from_defaults(\n",
-    "    llm=llm, \n",
-    "    transformations=transformations,\n",
-    "    callback_manager=callback_manager,\n",
-    ")\n",
-    "index = VectorStoreIndex.from_documents(\n",
-    "    documents, service_context=service_context\n",
-    ")"
-   ],
+   "execution_count": 19,
+   "id": "d75dfec0a2734d2d",
    "metadata": {
-    "collapsed": false,
     "ExecuteTime": {
      "end_time": "2024-05-10T13:03:40.003563Z",
      "start_time": "2024-05-10T13:03:39.420543Z"
-    }
+    },
+    "collapsed": false
    },
-   "id": "d75dfec0a2734d2d",
    "outputs": [
     {
      "name": "stdout",
@@ -527,10 +526,23 @@
      ]
     }
    ],
-   "execution_count": 19
+   "source": [
+    "llm = OpenAI(model=\"gpt-3.5-turbo\", temperature=0.1, output_parser=output_parser)\n",
+    "\n",
+    "service_context = ServiceContext.from_defaults(\n",
+    "    llm=llm,\n",
+    "    transformations=transformations,\n",
+    "    callback_manager=callback_manager,\n",
+    ")\n",
+    "index = VectorStoreIndex.from_documents(documents, service_context=service_context)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "dc3be69ad9b8f66b",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "We have two options on integrating LLM Guard for the input:\n",
     "\n",
@@ -538,14 +550,20 @@
     "2. Ingestion pipeline [transformation](https://docs.llamaindex.ai/en/stable/module_guides/loading/ingestion_pipeline/transformations.html)\n",
     "\n",
     "We will use the first option but in the real application, we should use both: clean data before ingestion and verify after retrieval. "
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "dc3be69ad9b8f66b"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 20,
+   "id": "2776c84ce0abc1c6",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-05-10T13:03:44.143412Z",
+     "start_time": "2024-05-10T13:03:44.135274Z"
+    },
+    "collapsed": false
+   },
+   "outputs": [],
    "source": [
     "from typing import List, Optional\n",
     "import logging\n",
@@ -554,6 +572,7 @@
     "from llama_index.core.schema import MetadataMode, NodeWithScore, QueryBundle\n",
     "\n",
     "logger = logging.getLogger(__name__)\n",
+    "\n",
     "\n",
     "class LLMGuardNodePostProcessor(BaseNodePostprocessor):\n",
     "    scanners: List = Field(description=\"Scanner objects\")\n",
@@ -572,7 +591,7 @@
     "    ) -> None:\n",
     "        if skip_scanners is None:\n",
     "            skip_scanners = []\n",
-    "        \n",
+    "\n",
     "        try:\n",
     "            import llm_guard\n",
     "        except ImportError:\n",
@@ -597,77 +616,52 @@
     "        query_bundle: Optional[QueryBundle] = None,\n",
     "    ) -> List[NodeWithScore]:\n",
     "        from llm_guard import scan_prompt\n",
-    "        \n",
+    "\n",
     "        safe_nodes = []\n",
     "        for node_with_score in nodes:\n",
     "            node = node_with_score.node\n",
-    "            \n",
+    "\n",
     "            sanitized_text, results_valid, results_score = scan_prompt(\n",
-    "                self.scanners, \n",
-    "                node.get_content(metadata_mode=MetadataMode.LLM), \n",
+    "                self.scanners,\n",
+    "                node.get_content(metadata_mode=MetadataMode.LLM),\n",
     "                self.fail_fast,\n",
     "            )\n",
-    "            \n",
+    "\n",
     "            for scanner_name in self.skip_scanners:\n",
     "                results_valid[scanner_name] = True\n",
-    "            \n",
+    "\n",
     "            if any(not result for result in results_valid.values()):\n",
     "                logger.warning(f\"Node `{node.node_id}` is not valid, scores: {results_score}\")\n",
-    "                \n",
+    "\n",
     "                continue\n",
-    "            \n",
+    "\n",
     "            node.set_content(sanitized_text)\n",
     "            safe_nodes.append(NodeWithScore(node=node, score=node_with_score.score))\n",
-    "            \n",
+    "\n",
     "        return safe_nodes"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2024-05-10T13:03:44.143412Z",
-     "start_time": "2024-05-10T13:03:44.135274Z"
-    }
-   },
-   "id": "2776c84ce0abc1c6",
-   "outputs": [],
-   "execution_count": 20
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Now we can configure input scanners."
-   ],
+   "id": "c341e0ce87848c31",
    "metadata": {
     "collapsed": false
    },
-   "id": "c341e0ce87848c31"
+   "source": [
+    "Now we can configure input scanners."
+   ]
   },
   {
    "cell_type": "code",
-   "source": [
-    "from llm_guard.input_scanners import Anonymize, PromptInjection, Toxicity, Secrets\n",
-    "\n",
-    "input_scanners = [\n",
-    "    Anonymize(vault, entity_types=[\"PERSON\", \"EMAIL_ADDRESS\", \"EMAIL_ADDRESS_RE\", \"PHONE_NUMBER\"]), \n",
-    "    Toxicity(), \n",
-    "    PromptInjection(),\n",
-    "    Secrets()\n",
-    "]\n",
-    "\n",
-    "llm_guard_postprocessor = LLMGuardNodePostProcessor(\n",
-    "    scanners=input_scanners,\n",
-    "    fail_fast=False,\n",
-    "    skip_scanners=[\"Anonymize\"],\n",
-    ")"
-   ],
+   "execution_count": 21,
+   "id": "a55bbfdbdb43162e",
    "metadata": {
-    "collapsed": false,
     "ExecuteTime": {
      "end_time": "2024-05-10T13:03:50.934080Z",
      "start_time": "2024-05-10T13:03:45.803336Z"
-    }
+    },
+    "collapsed": false
    },
-   "id": "a55bbfdbdb43162e",
    "outputs": [
     {
      "name": "stdout",
@@ -676,22 +670,22 @@
       "INFO:presidio-analyzer:Loaded recognizer: Transformers model Isotonic/deberta-v3-base_finetuned_ai4privacy_v2\n",
       "Loaded recognizer: Transformers model Isotonic/deberta-v3-base_finetuned_ai4privacy_v2\n",
       "Loaded recognizer: Transformers model Isotonic/deberta-v3-base_finetuned_ai4privacy_v2\n",
-      "\u001B[2m2024-05-10 15:03:47\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mInitialized NER model         \u001B[0m \u001B[36mdevice\u001B[0m=\u001B[35mdevice(type='mps')\u001B[0m \u001B[36mmodel\u001B[0m=\u001B[35mModel(path='Isotonic/deberta-v3-base_finetuned_ai4privacy_v2', subfolder='', revision='9ea992753ab2686be4a8f64605ccc7be197ad794', onnx_path='Isotonic/deberta-v3-base_finetuned_ai4privacy_v2', onnx_revision='9ea992753ab2686be4a8f64605ccc7be197ad794', onnx_subfolder='onnx', onnx_filename='model.onnx', onnx_enable_hack=True, kwargs={}, pipeline_kwargs={'aggregation_strategy': 'simple'})\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:47\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mLoaded regex pattern          \u001B[0m \u001B[36mgroup_name\u001B[0m=\u001B[35mCREDIT_CARD_RE\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:47\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mLoaded regex pattern          \u001B[0m \u001B[36mgroup_name\u001B[0m=\u001B[35mUUID\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:47\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mLoaded regex pattern          \u001B[0m \u001B[36mgroup_name\u001B[0m=\u001B[35mEMAIL_ADDRESS_RE\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:47\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mLoaded regex pattern          \u001B[0m \u001B[36mgroup_name\u001B[0m=\u001B[35mUS_SSN_RE\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:47\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mLoaded regex pattern          \u001B[0m \u001B[36mgroup_name\u001B[0m=\u001B[35mBTC_ADDRESS\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:47\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mLoaded regex pattern          \u001B[0m \u001B[36mgroup_name\u001B[0m=\u001B[35mURL_RE\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:47\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mLoaded regex pattern          \u001B[0m \u001B[36mgroup_name\u001B[0m=\u001B[35mCREDIT_CARD\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:47\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mLoaded regex pattern          \u001B[0m \u001B[36mgroup_name\u001B[0m=\u001B[35mEMAIL_ADDRESS_RE\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:47\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mLoaded regex pattern          \u001B[0m \u001B[36mgroup_name\u001B[0m=\u001B[35mPHONE_NUMBER_ZH\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:47\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mLoaded regex pattern          \u001B[0m \u001B[36mgroup_name\u001B[0m=\u001B[35mPHONE_NUMBER_WITH_EXT\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:47\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mLoaded regex pattern          \u001B[0m \u001B[36mgroup_name\u001B[0m=\u001B[35mDATE_RE\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:47\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mLoaded regex pattern          \u001B[0m \u001B[36mgroup_name\u001B[0m=\u001B[35mTIME_RE\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:47\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mLoaded regex pattern          \u001B[0m \u001B[36mgroup_name\u001B[0m=\u001B[35mHEX_COLOR\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:47\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mLoaded regex pattern          \u001B[0m \u001B[36mgroup_name\u001B[0m=\u001B[35mPRICE_RE\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:47\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mLoaded regex pattern          \u001B[0m \u001B[36mgroup_name\u001B[0m=\u001B[35mPO_BOX_RE\u001B[0m\n",
+      "\u001b[2m2024-05-10 15:03:47\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mInitialized NER model         \u001b[0m \u001b[36mdevice\u001b[0m=\u001b[35mdevice(type='mps')\u001b[0m \u001b[36mmodel\u001b[0m=\u001b[35mModel(path='Isotonic/deberta-v3-base_finetuned_ai4privacy_v2', subfolder='', revision='9ea992753ab2686be4a8f64605ccc7be197ad794', onnx_path='Isotonic/deberta-v3-base_finetuned_ai4privacy_v2', onnx_revision='9ea992753ab2686be4a8f64605ccc7be197ad794', onnx_subfolder='onnx', onnx_filename='model.onnx', onnx_enable_hack=True, kwargs={}, pipeline_kwargs={'aggregation_strategy': 'simple'})\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:47\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mLoaded regex pattern          \u001b[0m \u001b[36mgroup_name\u001b[0m=\u001b[35mCREDIT_CARD_RE\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:47\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mLoaded regex pattern          \u001b[0m \u001b[36mgroup_name\u001b[0m=\u001b[35mUUID\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:47\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mLoaded regex pattern          \u001b[0m \u001b[36mgroup_name\u001b[0m=\u001b[35mEMAIL_ADDRESS_RE\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:47\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mLoaded regex pattern          \u001b[0m \u001b[36mgroup_name\u001b[0m=\u001b[35mUS_SSN_RE\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:47\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mLoaded regex pattern          \u001b[0m \u001b[36mgroup_name\u001b[0m=\u001b[35mBTC_ADDRESS\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:47\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mLoaded regex pattern          \u001b[0m \u001b[36mgroup_name\u001b[0m=\u001b[35mURL_RE\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:47\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mLoaded regex pattern          \u001b[0m \u001b[36mgroup_name\u001b[0m=\u001b[35mCREDIT_CARD\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:47\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mLoaded regex pattern          \u001b[0m \u001b[36mgroup_name\u001b[0m=\u001b[35mEMAIL_ADDRESS_RE\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:47\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mLoaded regex pattern          \u001b[0m \u001b[36mgroup_name\u001b[0m=\u001b[35mPHONE_NUMBER_ZH\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:47\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mLoaded regex pattern          \u001b[0m \u001b[36mgroup_name\u001b[0m=\u001b[35mPHONE_NUMBER_WITH_EXT\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:47\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mLoaded regex pattern          \u001b[0m \u001b[36mgroup_name\u001b[0m=\u001b[35mDATE_RE\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:47\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mLoaded regex pattern          \u001b[0m \u001b[36mgroup_name\u001b[0m=\u001b[35mTIME_RE\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:47\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mLoaded regex pattern          \u001b[0m \u001b[36mgroup_name\u001b[0m=\u001b[35mHEX_COLOR\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:47\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mLoaded regex pattern          \u001b[0m \u001b[36mgroup_name\u001b[0m=\u001b[35mPRICE_RE\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:47\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mLoaded regex pattern          \u001b[0m \u001b[36mgroup_name\u001b[0m=\u001b[35mPO_BOX_RE\u001b[0m\n",
       "WARNING:presidio-analyzer:model_to_presidio_entity_mapping is missing from configuration, using default\n",
       "model_to_presidio_entity_mapping is missing from configuration, using default\n",
       "model_to_presidio_entity_mapping is missing from configuration, using default\n",
@@ -818,41 +812,49 @@
       "INFO:presidio-analyzer:Removed 1 recognizers which had the name SpacyRecognizer\n",
       "Removed 1 recognizers which had the name SpacyRecognizer\n",
       "Removed 1 recognizers which had the name SpacyRecognizer\n",
-      "\u001B[2m2024-05-10 15:03:49\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mInitialized classification model\u001B[0m \u001B[36mdevice\u001B[0m=\u001B[35mdevice(type='mps')\u001B[0m \u001B[36mmodel\u001B[0m=\u001B[35mModel(path='unitary/unbiased-toxic-roberta', subfolder='', revision='36295dd80b422dc49f40052021430dae76241adc', onnx_path='ProtectAI/unbiased-toxic-roberta-onnx', onnx_revision='34480fa958f6657ad835c345808475755b6974a7', onnx_subfolder='', onnx_filename='model.onnx', onnx_enable_hack=True, kwargs={}, pipeline_kwargs={'padding': 'max_length', 'top_k': None, 'function_to_apply': 'sigmoid', 'truncation': True})\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:50\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mInitialized classification model\u001B[0m \u001B[36mdevice\u001B[0m=\u001B[35mdevice(type='mps')\u001B[0m \u001B[36mmodel\u001B[0m=\u001B[35mModel(path='protectai/deberta-v3-base-prompt-injection', subfolder='', revision='f51c3b2a5216ae1af467b511bc7e3b78dc4a99c9', onnx_path='ProtectAI/deberta-v3-base-prompt-injection', onnx_revision='f51c3b2a5216ae1af467b511bc7e3b78dc4a99c9', onnx_subfolder='onnx', onnx_filename='model.onnx', onnx_enable_hack=True, kwargs={}, pipeline_kwargs={'max_length': 512, 'truncation': True})\u001B[0m\n"
+      "\u001b[2m2024-05-10 15:03:49\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mInitialized classification model\u001b[0m \u001b[36mdevice\u001b[0m=\u001b[35mdevice(type='mps')\u001b[0m \u001b[36mmodel\u001b[0m=\u001b[35mModel(path='unitary/unbiased-toxic-roberta', subfolder='', revision='36295dd80b422dc49f40052021430dae76241adc', onnx_path='ProtectAI/unbiased-toxic-roberta-onnx', onnx_revision='34480fa958f6657ad835c345808475755b6974a7', onnx_subfolder='', onnx_filename='model.onnx', onnx_enable_hack=True, kwargs={}, pipeline_kwargs={'padding': 'max_length', 'top_k': None, 'function_to_apply': 'sigmoid', 'truncation': True})\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:50\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mInitialized classification model\u001b[0m \u001b[36mdevice\u001b[0m=\u001b[35mdevice(type='mps')\u001b[0m \u001b[36mmodel\u001b[0m=\u001b[35mModel(path='protectai/deberta-v3-base-prompt-injection', subfolder='', revision='f51c3b2a5216ae1af467b511bc7e3b78dc4a99c9', onnx_path='ProtectAI/deberta-v3-base-prompt-injection', onnx_revision='f51c3b2a5216ae1af467b511bc7e3b78dc4a99c9', onnx_subfolder='onnx', onnx_filename='model.onnx', onnx_enable_hack=True, kwargs={}, pipeline_kwargs={'max_length': 512, 'truncation': True})\u001b[0m\n"
      ]
     }
    ],
-   "execution_count": 21
+   "source": [
+    "from llm_guard.input_scanners import Anonymize, PromptInjection, Toxicity, Secrets\n",
+    "\n",
+    "input_scanners = [\n",
+    "    Anonymize(vault, entity_types=[\"PERSON\", \"EMAIL_ADDRESS\", \"EMAIL_ADDRESS_RE\", \"PHONE_NUMBER\"]),\n",
+    "    Toxicity(),\n",
+    "    PromptInjection(),\n",
+    "    Secrets(),\n",
+    "]\n",
+    "\n",
+    "llm_guard_postprocessor = LLMGuardNodePostProcessor(\n",
+    "    scanners=input_scanners,\n",
+    "    fail_fast=False,\n",
+    "    skip_scanners=[\"Anonymize\"],\n",
+    ")"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "And finally, we can run the query again."
-   ],
+   "id": "581ec0a074103c6b",
    "metadata": {
     "collapsed": false
    },
-   "id": "581ec0a074103c6b"
+   "source": [
+    "And finally, we can run the query again."
+   ]
   },
   {
    "cell_type": "code",
-   "source": [
-    "query_engine = index.as_query_engine(\n",
-    "    similarity_top_k=3,\n",
-    "    node_postprocessors=[llm_guard_postprocessor]\n",
-    ")\n",
-    "response = query_engine.query(\"I am screening candidates for adult caregiving opportunity. Please recommend me an experienced person. Return just a name\")\n",
-    "print(str(response))"
-   ],
+   "execution_count": 22,
+   "id": "2bc2dd4fad71f745",
    "metadata": {
-    "collapsed": false,
     "ExecuteTime": {
      "end_time": "2024-05-10T13:03:55.374709Z",
      "start_time": "2024-05-10T13:03:50.935598Z"
-    }
+    },
+    "collapsed": false
    },
-   "id": "2bc2dd4fad71f745",
    "outputs": [
     {
      "name": "stdout",
@@ -886,158 +888,163 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mDATE_TIME\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mLOCATION\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mLOCATION\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mLOCATION\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mLOCATION\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mLOCATION\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[33m\u001B[1mwarning  \u001B[0m] \u001B[1mFound entity which is not supported by Presidio\u001B[0m \u001B[36mentity\u001B[0m=\u001B[35mAGE\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mAGE\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[33m\u001B[1mwarning  \u001B[0m] \u001B[1mFound entity which is not supported by Presidio\u001B[0m \u001B[36mentity\u001B[0m=\u001B[35mDATE_OF_BIRTH\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mDATE_OF_BIRTH\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mLOCATION\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[33m\u001B[1mwarning  \u001B[0m] \u001B[1mFound unrecognized label, returning entity as is\u001B[0m \u001B[36mlabel\u001B[0m=\u001B[35mUSERNAME\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mUSERNAME\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mLOCATION\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mLOCATION\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mLOCATION\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mURL\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[33m\u001B[1mwarning  \u001B[0m] \u001B[1mFound entity which is not supported by Presidio\u001B[0m \u001B[36mentity\u001B[0m=\u001B[35mDATE_OF_BIRTH\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mDATE_OF_BIRTH\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mDATE_TIME\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mLOCATION\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mLOCATION\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mLOCATION\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[33m\u001B[1mwarning  \u001B[0m] \u001B[1mFound entity which is not supported by Presidio\u001B[0m \u001B[36mentity\u001B[0m=\u001B[35mAGE\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mAGE\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mLOCATION\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mLOCATION\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mLOCATION\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mremoving element type: EMAIL_ADDRESS_RE, start: 118, end: 137, score: 0.75 from results list due to conflict\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[33m\u001B[1mwarning  \u001B[0m] \u001B[1mFound sensitive data in the prompt and replaced it\u001B[0m \u001B[36mmerged_results\u001B[0m=\u001B[35m[type: PHONE_NUMBER, start: 100, end: 115, score: 0.9700000286102295, type: EMAIL_ADDRESS, start: 118, end: 137, score: 1.0]\u001B[0m \u001B[36mrisk_score\u001B[0m=\u001B[35m1.0\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:51\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mScanner completed             \u001B[0m \u001B[36melapsed_time_seconds\u001B[0m=\u001B[35m0.726767\u001B[0m \u001B[36mis_valid\u001B[0m=\u001B[35mFalse\u001B[0m \u001B[36mscanner\u001B[0m=\u001B[35mAnonymize\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:52\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mNot toxicity found in the text\u001B[0m \u001B[36mresults\u001B[0m=\u001B[35m[[{'label': 'male', 'score': 0.3784036636352539}, {'label': 'psychiatric_or_mental_illness', 'score': 0.02831844985485077}, {'label': 'toxicity', 'score': 0.004705189261585474}, {'label': 'insult', 'score': 0.00256668240763247}, {'label': 'female', 'score': 0.0005565687897615135}, {'label': 'sexual_explicit', 'score': 0.0003133361169602722}, {'label': 'white', 'score': 0.00029167189495638013}, {'label': 'threat', 'score': 0.0002404669503448531}, {'label': 'obscene', 'score': 0.00018776571960188448}, {'label': 'identity_attack', 'score': 0.00016007180965971202}, {'label': 'black', 'score': 0.00010811129322974011}, {'label': 'muslim', 'score': 9.321052493760362e-05}, {'label': 'homosexual_gay_or_lesbian', 'score': 7.381540490314364e-05}, {'label': 'jewish', 'score': 6.264982948778197e-05}, {'label': 'christian', 'score': 6.264696276048198e-05}, {'label': 'severe_toxicity', 'score': 1.7427058992325328e-05}]]\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:52\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mScanner completed             \u001B[0m \u001B[36melapsed_time_seconds\u001B[0m=\u001B[35m0.297684\u001B[0m \u001B[36mis_valid\u001B[0m=\u001B[35mTrue\u001B[0m \u001B[36mscanner\u001B[0m=\u001B[35mToxicity\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:52\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mNo prompt injection detected  \u001B[0m \u001B[36mhighest_score\u001B[0m=\u001B[35m0.0\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:52\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mScanner completed             \u001B[0m \u001B[36melapsed_time_seconds\u001B[0m=\u001B[35m0.296037\u001B[0m \u001B[36mis_valid\u001B[0m=\u001B[35mTrue\u001B[0m \u001B[36mscanner\u001B[0m=\u001B[35mPromptInjection\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:52\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mNo secrets detected in the prompt\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:52\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mScanner completed             \u001B[0m \u001B[36melapsed_time_seconds\u001B[0m=\u001B[35m0.076863\u001B[0m \u001B[36mis_valid\u001B[0m=\u001B[35mTrue\u001B[0m \u001B[36mscanner\u001B[0m=\u001B[35mSecrets\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:52\u001B[0m [\u001B[32m\u001B[1minfo     \u001B[0m] \u001B[1mScanned prompt                \u001B[0m \u001B[36melapsed_time_seconds\u001B[0m=\u001B[35m1.398427\u001B[0m \u001B[36mscores\u001B[0m=\u001B[35m{'Anonymize': 1.0, 'Toxicity': 0.0, 'PromptInjection': 0.0, 'Secrets': 0.0}\u001B[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mDATE_TIME\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mLOCATION\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mLOCATION\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mLOCATION\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mLOCATION\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mLOCATION\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[33m\u001b[1mwarning  \u001b[0m] \u001b[1mFound entity which is not supported by Presidio\u001b[0m \u001b[36mentity\u001b[0m=\u001b[35mAGE\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mAGE\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[33m\u001b[1mwarning  \u001b[0m] \u001b[1mFound entity which is not supported by Presidio\u001b[0m \u001b[36mentity\u001b[0m=\u001b[35mDATE_OF_BIRTH\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mDATE_OF_BIRTH\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mLOCATION\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[33m\u001b[1mwarning  \u001b[0m] \u001b[1mFound unrecognized label, returning entity as is\u001b[0m \u001b[36mlabel\u001b[0m=\u001b[35mUSERNAME\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mUSERNAME\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mLOCATION\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mLOCATION\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mLOCATION\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mURL\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[33m\u001b[1mwarning  \u001b[0m] \u001b[1mFound entity which is not supported by Presidio\u001b[0m \u001b[36mentity\u001b[0m=\u001b[35mDATE_OF_BIRTH\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mDATE_OF_BIRTH\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mDATE_TIME\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mLOCATION\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mLOCATION\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mLOCATION\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[33m\u001b[1mwarning  \u001b[0m] \u001b[1mFound entity which is not supported by Presidio\u001b[0m \u001b[36mentity\u001b[0m=\u001b[35mAGE\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mAGE\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mLOCATION\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mLOCATION\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mLOCATION\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mremoving element type: EMAIL_ADDRESS_RE, start: 118, end: 137, score: 0.75 from results list due to conflict\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[33m\u001b[1mwarning  \u001b[0m] \u001b[1mFound sensitive data in the prompt and replaced it\u001b[0m \u001b[36mmerged_results\u001b[0m=\u001b[35m[type: PHONE_NUMBER, start: 100, end: 115, score: 0.9700000286102295, type: EMAIL_ADDRESS, start: 118, end: 137, score: 1.0]\u001b[0m \u001b[36mrisk_score\u001b[0m=\u001b[35m1.0\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:51\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mScanner completed             \u001b[0m \u001b[36melapsed_time_seconds\u001b[0m=\u001b[35m0.726767\u001b[0m \u001b[36mis_valid\u001b[0m=\u001b[35mFalse\u001b[0m \u001b[36mscanner\u001b[0m=\u001b[35mAnonymize\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:52\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mNot toxicity found in the text\u001b[0m \u001b[36mresults\u001b[0m=\u001b[35m[[{'label': 'male', 'score': 0.3784036636352539}, {'label': 'psychiatric_or_mental_illness', 'score': 0.02831844985485077}, {'label': 'toxicity', 'score': 0.004705189261585474}, {'label': 'insult', 'score': 0.00256668240763247}, {'label': 'female', 'score': 0.0005565687897615135}, {'label': 'sexual_explicit', 'score': 0.0003133361169602722}, {'label': 'white', 'score': 0.00029167189495638013}, {'label': 'threat', 'score': 0.0002404669503448531}, {'label': 'obscene', 'score': 0.00018776571960188448}, {'label': 'identity_attack', 'score': 0.00016007180965971202}, {'label': 'black', 'score': 0.00010811129322974011}, {'label': 'muslim', 'score': 9.321052493760362e-05}, {'label': 'homosexual_gay_or_lesbian', 'score': 7.381540490314364e-05}, {'label': 'jewish', 'score': 6.264982948778197e-05}, {'label': 'christian', 'score': 6.264696276048198e-05}, {'label': 'severe_toxicity', 'score': 1.7427058992325328e-05}]]\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:52\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mScanner completed             \u001b[0m \u001b[36melapsed_time_seconds\u001b[0m=\u001b[35m0.297684\u001b[0m \u001b[36mis_valid\u001b[0m=\u001b[35mTrue\u001b[0m \u001b[36mscanner\u001b[0m=\u001b[35mToxicity\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:52\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mNo prompt injection detected  \u001b[0m \u001b[36mhighest_score\u001b[0m=\u001b[35m0.0\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:52\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mScanner completed             \u001b[0m \u001b[36melapsed_time_seconds\u001b[0m=\u001b[35m0.296037\u001b[0m \u001b[36mis_valid\u001b[0m=\u001b[35mTrue\u001b[0m \u001b[36mscanner\u001b[0m=\u001b[35mPromptInjection\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:52\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mNo secrets detected in the prompt\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:52\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mScanner completed             \u001b[0m \u001b[36melapsed_time_seconds\u001b[0m=\u001b[35m0.076863\u001b[0m \u001b[36mis_valid\u001b[0m=\u001b[35mTrue\u001b[0m \u001b[36mscanner\u001b[0m=\u001b[35mSecrets\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:52\u001b[0m [\u001b[32m\u001b[1minfo     \u001b[0m] \u001b[1mScanned prompt                \u001b[0m \u001b[36melapsed_time_seconds\u001b[0m=\u001b[35m1.398427\u001b[0m \u001b[36mscores\u001b[0m=\u001b[35m{'Anonymize': 1.0, 'Toxicity': 0.0, 'PromptInjection': 0.0, 'Secrets': 0.0}\u001b[0m\n",
       "WARNING:presidio-analyzer:Entity CUSTOM doesn't have the corresponding recognizer in language : en\n",
       "Entity CUSTOM doesn't have the corresponding recognizer in language : en\n",
       "Entity CUSTOM doesn't have the corresponding recognizer in language : en\n",
       "WARNING:presidio-analyzer:Entity FAC is not mapped to a Presidio entity, but keeping anyway. Add to `NerModelConfiguration.labels_to_ignore` to remove.\n",
       "Entity FAC is not mapped to a Presidio entity, but keeping anyway. Add to `NerModelConfiguration.labels_to_ignore` to remove.\n",
       "Entity FAC is not mapped to a Presidio entity, but keeping anyway. Add to `NerModelConfiguration.labels_to_ignore` to remove.\n",
-      "\u001B[2m2024-05-10 15:03:52\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mURL\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:52\u001B[0m [\u001B[33m\u001B[1mwarning  \u001B[0m] \u001B[1mFound entity which is not supported by Presidio\u001B[0m \u001B[36mentity\u001B[0m=\u001B[35mAGE\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:52\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mAGE\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:52\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mLOCATION\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:52\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mLOCATION\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:52\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mDATE_TIME\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:52\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mDATE_TIME\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:52\u001B[0m [\u001B[33m\u001B[1mwarning  \u001B[0m] \u001B[1mFound entity which is not supported by Presidio\u001B[0m \u001B[36mentity\u001B[0m=\u001B[35mDATE_OF_BIRTH\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:52\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mDATE_OF_BIRTH\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:52\u001B[0m [\u001B[33m\u001B[1mwarning  \u001B[0m] \u001B[1mFound entity which is not supported by Presidio\u001B[0m \u001B[36mentity\u001B[0m=\u001B[35mDATE_OF_BIRTH\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:52\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mDATE_OF_BIRTH\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:52\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mLOCATION\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:52\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mLOCATION\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:52\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mDATE_TIME\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:52\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mLOCATION\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:52\u001B[0m [\u001B[33m\u001B[1mwarning  \u001B[0m] \u001B[1mFound entity which is not supported by Presidio\u001B[0m \u001B[36mentity\u001B[0m=\u001B[35mDATE_OF_BIRTH\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:52\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mDATE_OF_BIRTH\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:52\u001B[0m [\u001B[33m\u001B[1mwarning  \u001B[0m] \u001B[1mFound sensitive data in the prompt and replaced it\u001B[0m \u001B[36mmerged_results\u001B[0m=\u001B[35m[type: PERSON, start: 59, end: 66, score: 0.5799999833106995, type: PHONE_NUMBER, start: 107, end: 109, score: 1.0, type: PHONE_NUMBER, start: 109, end: 127, score: 1.0, type: EMAIL_ADDRESS, start: 130, end: 154, score: 1.0]\u001B[0m \u001B[36mrisk_score\u001B[0m=\u001B[35m1.0\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:52\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mScanner completed             \u001B[0m \u001B[36melapsed_time_seconds\u001B[0m=\u001B[35m0.322093\u001B[0m \u001B[36mis_valid\u001B[0m=\u001B[35mFalse\u001B[0m \u001B[36mscanner\u001B[0m=\u001B[35mAnonymize\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mNot toxicity found in the text\u001B[0m \u001B[36mresults\u001B[0m=\u001B[35m[[{'label': 'male', 'score': 0.30273741483688354}, {'label': 'psychiatric_or_mental_illness', 'score': 0.028437014669179916}, {'label': 'toxicity', 'score': 0.003292717970907688}, {'label': 'insult', 'score': 0.0017260991735383868}, {'label': 'female', 'score': 0.0004832090635318309}, {'label': 'white', 'score': 0.0003159895131830126}, {'label': 'sexual_explicit', 'score': 0.0002675407158676535}, {'label': 'threat', 'score': 0.00019579993386287242}, {'label': 'obscene', 'score': 0.0001691716752247885}, {'label': 'identity_attack', 'score': 0.00013108628627378494}, {'label': 'black', 'score': 0.00010416842269478366}, {'label': 'muslim', 'score': 8.162993617588654e-05}, {'label': 'homosexual_gay_or_lesbian', 'score': 7.954372995300218e-05}, {'label': 'christian', 'score': 6.015866529196501e-05}, {'label': 'jewish', 'score': 5.7889974414138123e-05}, {'label': 'severe_toxicity', 'score': 1.5702362361480482e-05}]]\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mScanner completed             \u001B[0m \u001B[36melapsed_time_seconds\u001B[0m=\u001B[35m0.175929\u001B[0m \u001B[36mis_valid\u001B[0m=\u001B[35mTrue\u001B[0m \u001B[36mscanner\u001B[0m=\u001B[35mToxicity\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mNo prompt injection detected  \u001B[0m \u001B[36mhighest_score\u001B[0m=\u001B[35m0.0\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mScanner completed             \u001B[0m \u001B[36melapsed_time_seconds\u001B[0m=\u001B[35m0.247473\u001B[0m \u001B[36mis_valid\u001B[0m=\u001B[35mTrue\u001B[0m \u001B[36mscanner\u001B[0m=\u001B[35mPromptInjection\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mNo secrets detected in the prompt\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mScanner completed             \u001B[0m \u001B[36melapsed_time_seconds\u001B[0m=\u001B[35m0.014925\u001B[0m \u001B[36mis_valid\u001B[0m=\u001B[35mTrue\u001B[0m \u001B[36mscanner\u001B[0m=\u001B[35mSecrets\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[32m\u001B[1minfo     \u001B[0m] \u001B[1mScanned prompt                \u001B[0m \u001B[36melapsed_time_seconds\u001B[0m=\u001B[35m0.761593\u001B[0m \u001B[36mscores\u001B[0m=\u001B[35m{'Anonymize': 1.0, 'Toxicity': 0.0, 'PromptInjection': 0.0, 'Secrets': 0.0}\u001B[0m\n",
+      "\u001b[2m2024-05-10 15:03:52\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mURL\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:52\u001b[0m [\u001b[33m\u001b[1mwarning  \u001b[0m] \u001b[1mFound entity which is not supported by Presidio\u001b[0m \u001b[36mentity\u001b[0m=\u001b[35mAGE\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:52\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mAGE\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:52\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mLOCATION\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:52\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mLOCATION\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:52\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mDATE_TIME\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:52\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mDATE_TIME\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:52\u001b[0m [\u001b[33m\u001b[1mwarning  \u001b[0m] \u001b[1mFound entity which is not supported by Presidio\u001b[0m \u001b[36mentity\u001b[0m=\u001b[35mDATE_OF_BIRTH\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:52\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mDATE_OF_BIRTH\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:52\u001b[0m [\u001b[33m\u001b[1mwarning  \u001b[0m] \u001b[1mFound entity which is not supported by Presidio\u001b[0m \u001b[36mentity\u001b[0m=\u001b[35mDATE_OF_BIRTH\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:52\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mDATE_OF_BIRTH\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:52\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mLOCATION\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:52\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mLOCATION\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:52\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mDATE_TIME\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:52\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mLOCATION\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:52\u001b[0m [\u001b[33m\u001b[1mwarning  \u001b[0m] \u001b[1mFound entity which is not supported by Presidio\u001b[0m \u001b[36mentity\u001b[0m=\u001b[35mDATE_OF_BIRTH\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:52\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mDATE_OF_BIRTH\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:52\u001b[0m [\u001b[33m\u001b[1mwarning  \u001b[0m] \u001b[1mFound sensitive data in the prompt and replaced it\u001b[0m \u001b[36mmerged_results\u001b[0m=\u001b[35m[type: PERSON, start: 59, end: 66, score: 0.5799999833106995, type: PHONE_NUMBER, start: 107, end: 109, score: 1.0, type: PHONE_NUMBER, start: 109, end: 127, score: 1.0, type: EMAIL_ADDRESS, start: 130, end: 154, score: 1.0]\u001b[0m \u001b[36mrisk_score\u001b[0m=\u001b[35m1.0\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:52\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mScanner completed             \u001b[0m \u001b[36melapsed_time_seconds\u001b[0m=\u001b[35m0.322093\u001b[0m \u001b[36mis_valid\u001b[0m=\u001b[35mFalse\u001b[0m \u001b[36mscanner\u001b[0m=\u001b[35mAnonymize\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mNot toxicity found in the text\u001b[0m \u001b[36mresults\u001b[0m=\u001b[35m[[{'label': 'male', 'score': 0.30273741483688354}, {'label': 'psychiatric_or_mental_illness', 'score': 0.028437014669179916}, {'label': 'toxicity', 'score': 0.003292717970907688}, {'label': 'insult', 'score': 0.0017260991735383868}, {'label': 'female', 'score': 0.0004832090635318309}, {'label': 'white', 'score': 0.0003159895131830126}, {'label': 'sexual_explicit', 'score': 0.0002675407158676535}, {'label': 'threat', 'score': 0.00019579993386287242}, {'label': 'obscene', 'score': 0.0001691716752247885}, {'label': 'identity_attack', 'score': 0.00013108628627378494}, {'label': 'black', 'score': 0.00010416842269478366}, {'label': 'muslim', 'score': 8.162993617588654e-05}, {'label': 'homosexual_gay_or_lesbian', 'score': 7.954372995300218e-05}, {'label': 'christian', 'score': 6.015866529196501e-05}, {'label': 'jewish', 'score': 5.7889974414138123e-05}, {'label': 'severe_toxicity', 'score': 1.5702362361480482e-05}]]\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mScanner completed             \u001b[0m \u001b[36melapsed_time_seconds\u001b[0m=\u001b[35m0.175929\u001b[0m \u001b[36mis_valid\u001b[0m=\u001b[35mTrue\u001b[0m \u001b[36mscanner\u001b[0m=\u001b[35mToxicity\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mNo prompt injection detected  \u001b[0m \u001b[36mhighest_score\u001b[0m=\u001b[35m0.0\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mScanner completed             \u001b[0m \u001b[36melapsed_time_seconds\u001b[0m=\u001b[35m0.247473\u001b[0m \u001b[36mis_valid\u001b[0m=\u001b[35mTrue\u001b[0m \u001b[36mscanner\u001b[0m=\u001b[35mPromptInjection\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mNo secrets detected in the prompt\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mScanner completed             \u001b[0m \u001b[36melapsed_time_seconds\u001b[0m=\u001b[35m0.014925\u001b[0m \u001b[36mis_valid\u001b[0m=\u001b[35mTrue\u001b[0m \u001b[36mscanner\u001b[0m=\u001b[35mSecrets\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[32m\u001b[1minfo     \u001b[0m] \u001b[1mScanned prompt                \u001b[0m \u001b[36melapsed_time_seconds\u001b[0m=\u001b[35m0.761593\u001b[0m \u001b[36mscores\u001b[0m=\u001b[35m{'Anonymize': 1.0, 'Toxicity': 0.0, 'PromptInjection': 0.0, 'Secrets': 0.0}\u001b[0m\n",
       "WARNING:presidio-analyzer:Entity CUSTOM doesn't have the corresponding recognizer in language : en\n",
       "Entity CUSTOM doesn't have the corresponding recognizer in language : en\n",
       "Entity CUSTOM doesn't have the corresponding recognizer in language : en\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[33m\u001B[1mwarning  \u001B[0m] \u001B[1mFound entity which is not supported by Presidio\u001B[0m \u001B[36mentity\u001B[0m=\u001B[35mDATE_OF_BIRTH\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mDATE_OF_BIRTH\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[33m\u001B[1mwarning  \u001B[0m] \u001B[1mFound unrecognized label, returning entity as is\u001B[0m \u001B[36mlabel\u001B[0m=\u001B[35mUSERNAME\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mUSERNAME\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mLOCATION\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mLOCATION\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mURL\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mDATE_TIME\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mDATE_TIME\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[33m\u001B[1mwarning  \u001B[0m] \u001B[1mFound entity which is not supported by Presidio\u001B[0m \u001B[36mentity\u001B[0m=\u001B[35mDATE_OF_BIRTH\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mDATE_OF_BIRTH\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mLOCATION\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[33m\u001B[1mwarning  \u001B[0m] \u001B[1mFound entity which is not supported by Presidio\u001B[0m \u001B[36mentity\u001B[0m=\u001B[35mDATE_OF_BIRTH\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mDATE_OF_BIRTH\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[33m\u001B[1mwarning  \u001B[0m] \u001B[1mFound entity which is not supported by Presidio\u001B[0m \u001B[36mentity\u001B[0m=\u001B[35mDATE_OF_BIRTH\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mDATE_OF_BIRTH\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[33m\u001B[1mwarning  \u001B[0m] \u001B[1mFound unrecognized label, returning entity as is\u001B[0m \u001B[36mlabel\u001B[0m=\u001B[35mUSERNAME\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mUSERNAME\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mURL\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mDATE_TIME\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[33m\u001B[1mwarning  \u001B[0m] \u001B[1mFound unrecognized label, returning entity as is\u001B[0m \u001B[36mlabel\u001B[0m=\u001B[35mUSERNAME\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mUSERNAME\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mIgnoring entity               \u001B[0m \u001B[36mentity_group\u001B[0m=\u001B[35mLOCATION\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[33m\u001B[1mwarning  \u001B[0m] \u001B[1mFound sensitive data in the prompt and replaced it\u001B[0m \u001B[36mmerged_results\u001B[0m=\u001B[35m[type: PERSON, start: 57, end: 64, score: 0.5299999713897705, type: PHONE_NUMBER, start: 105, end: 107, score: 1.0, type: PHONE_NUMBER, start: 107, end: 125, score: 1.0, type: EMAIL_ADDRESS, start: 128, end: 150, score: 1.0]\u001B[0m \u001B[36mrisk_score\u001B[0m=\u001B[35m1.0\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mScanner completed             \u001B[0m \u001B[36melapsed_time_seconds\u001B[0m=\u001B[35m0.316987\u001B[0m \u001B[36mis_valid\u001B[0m=\u001B[35mFalse\u001B[0m \u001B[36mscanner\u001B[0m=\u001B[35mAnonymize\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mNot toxicity found in the text\u001B[0m \u001B[36mresults\u001B[0m=\u001B[35m[[{'label': 'toxicity', 'score': 0.016027674078941345}, {'label': 'insult', 'score': 0.008662614040076733}, {'label': 'psychiatric_or_mental_illness', 'score': 0.00474339397624135}, {'label': 'male', 'score': 0.0013081864453852177}, {'label': 'obscene', 'score': 0.0007996137137524784}, {'label': 'threat', 'score': 0.0005580223514698446}, {'label': 'sexual_explicit', 'score': 0.00039813603507354856}, {'label': 'identity_attack', 'score': 0.00011789896234404296}, {'label': 'white', 'score': 9.211573342327029e-05}, {'label': 'female', 'score': 8.379467180930078e-05}, {'label': 'muslim', 'score': 7.278045086422935e-05}, {'label': 'black', 'score': 4.098531280760653e-05}, {'label': 'christian', 'score': 4.037902181153186e-05}, {'label': 'homosexual_gay_or_lesbian', 'score': 2.2601758246310055e-05}, {'label': 'jewish', 'score': 1.5769472156534903e-05}, {'label': 'severe_toxicity', 'score': 7.866138730605599e-06}]]\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:53\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mScanner completed             \u001B[0m \u001B[36melapsed_time_seconds\u001B[0m=\u001B[35m0.258387\u001B[0m \u001B[36mis_valid\u001B[0m=\u001B[35mTrue\u001B[0m \u001B[36mscanner\u001B[0m=\u001B[35mToxicity\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:54\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mNo prompt injection detected  \u001B[0m \u001B[36mhighest_score\u001B[0m=\u001B[35m0.0\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:54\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mScanner completed             \u001B[0m \u001B[36melapsed_time_seconds\u001B[0m=\u001B[35m0.260534\u001B[0m \u001B[36mis_valid\u001B[0m=\u001B[35mTrue\u001B[0m \u001B[36mscanner\u001B[0m=\u001B[35mPromptInjection\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:54\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mNo secrets detected in the prompt\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:54\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mScanner completed             \u001B[0m \u001B[36melapsed_time_seconds\u001B[0m=\u001B[35m0.014808\u001B[0m \u001B[36mis_valid\u001B[0m=\u001B[35mTrue\u001B[0m \u001B[36mscanner\u001B[0m=\u001B[35mSecrets\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:54\u001B[0m [\u001B[32m\u001B[1minfo     \u001B[0m] \u001B[1mScanned prompt                \u001B[0m \u001B[36melapsed_time_seconds\u001B[0m=\u001B[35m0.851842\u001B[0m \u001B[36mscores\u001B[0m=\u001B[35m{'Anonymize': 1.0, 'Toxicity': 0.0, 'PromptInjection': 0.0, 'Secrets': 0.0}\u001B[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[33m\u001b[1mwarning  \u001b[0m] \u001b[1mFound entity which is not supported by Presidio\u001b[0m \u001b[36mentity\u001b[0m=\u001b[35mDATE_OF_BIRTH\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mDATE_OF_BIRTH\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[33m\u001b[1mwarning  \u001b[0m] \u001b[1mFound unrecognized label, returning entity as is\u001b[0m \u001b[36mlabel\u001b[0m=\u001b[35mUSERNAME\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mUSERNAME\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mLOCATION\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mLOCATION\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mURL\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mDATE_TIME\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mDATE_TIME\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[33m\u001b[1mwarning  \u001b[0m] \u001b[1mFound entity which is not supported by Presidio\u001b[0m \u001b[36mentity\u001b[0m=\u001b[35mDATE_OF_BIRTH\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mDATE_OF_BIRTH\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mLOCATION\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[33m\u001b[1mwarning  \u001b[0m] \u001b[1mFound entity which is not supported by Presidio\u001b[0m \u001b[36mentity\u001b[0m=\u001b[35mDATE_OF_BIRTH\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mDATE_OF_BIRTH\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[33m\u001b[1mwarning  \u001b[0m] \u001b[1mFound entity which is not supported by Presidio\u001b[0m \u001b[36mentity\u001b[0m=\u001b[35mDATE_OF_BIRTH\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mDATE_OF_BIRTH\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[33m\u001b[1mwarning  \u001b[0m] \u001b[1mFound unrecognized label, returning entity as is\u001b[0m \u001b[36mlabel\u001b[0m=\u001b[35mUSERNAME\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mUSERNAME\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mURL\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mDATE_TIME\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[33m\u001b[1mwarning  \u001b[0m] \u001b[1mFound unrecognized label, returning entity as is\u001b[0m \u001b[36mlabel\u001b[0m=\u001b[35mUSERNAME\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mUSERNAME\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mIgnoring entity               \u001b[0m \u001b[36mentity_group\u001b[0m=\u001b[35mLOCATION\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[33m\u001b[1mwarning  \u001b[0m] \u001b[1mFound sensitive data in the prompt and replaced it\u001b[0m \u001b[36mmerged_results\u001b[0m=\u001b[35m[type: PERSON, start: 57, end: 64, score: 0.5299999713897705, type: PHONE_NUMBER, start: 105, end: 107, score: 1.0, type: PHONE_NUMBER, start: 107, end: 125, score: 1.0, type: EMAIL_ADDRESS, start: 128, end: 150, score: 1.0]\u001b[0m \u001b[36mrisk_score\u001b[0m=\u001b[35m1.0\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mScanner completed             \u001b[0m \u001b[36melapsed_time_seconds\u001b[0m=\u001b[35m0.316987\u001b[0m \u001b[36mis_valid\u001b[0m=\u001b[35mFalse\u001b[0m \u001b[36mscanner\u001b[0m=\u001b[35mAnonymize\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mNot toxicity found in the text\u001b[0m \u001b[36mresults\u001b[0m=\u001b[35m[[{'label': 'toxicity', 'score': 0.016027674078941345}, {'label': 'insult', 'score': 0.008662614040076733}, {'label': 'psychiatric_or_mental_illness', 'score': 0.00474339397624135}, {'label': 'male', 'score': 0.0013081864453852177}, {'label': 'obscene', 'score': 0.0007996137137524784}, {'label': 'threat', 'score': 0.0005580223514698446}, {'label': 'sexual_explicit', 'score': 0.00039813603507354856}, {'label': 'identity_attack', 'score': 0.00011789896234404296}, {'label': 'white', 'score': 9.211573342327029e-05}, {'label': 'female', 'score': 8.379467180930078e-05}, {'label': 'muslim', 'score': 7.278045086422935e-05}, {'label': 'black', 'score': 4.098531280760653e-05}, {'label': 'christian', 'score': 4.037902181153186e-05}, {'label': 'homosexual_gay_or_lesbian', 'score': 2.2601758246310055e-05}, {'label': 'jewish', 'score': 1.5769472156534903e-05}, {'label': 'severe_toxicity', 'score': 7.866138730605599e-06}]]\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:53\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mScanner completed             \u001b[0m \u001b[36melapsed_time_seconds\u001b[0m=\u001b[35m0.258387\u001b[0m \u001b[36mis_valid\u001b[0m=\u001b[35mTrue\u001b[0m \u001b[36mscanner\u001b[0m=\u001b[35mToxicity\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:54\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mNo prompt injection detected  \u001b[0m \u001b[36mhighest_score\u001b[0m=\u001b[35m0.0\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:54\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mScanner completed             \u001b[0m \u001b[36melapsed_time_seconds\u001b[0m=\u001b[35m0.260534\u001b[0m \u001b[36mis_valid\u001b[0m=\u001b[35mTrue\u001b[0m \u001b[36mscanner\u001b[0m=\u001b[35mPromptInjection\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:54\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mNo secrets detected in the prompt\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:54\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mScanner completed             \u001b[0m \u001b[36melapsed_time_seconds\u001b[0m=\u001b[35m0.014808\u001b[0m \u001b[36mis_valid\u001b[0m=\u001b[35mTrue\u001b[0m \u001b[36mscanner\u001b[0m=\u001b[35mSecrets\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:54\u001b[0m [\u001b[32m\u001b[1minfo     \u001b[0m] \u001b[1mScanned prompt                \u001b[0m \u001b[36melapsed_time_seconds\u001b[0m=\u001b[35m0.851842\u001b[0m \u001b[36mscores\u001b[0m=\u001b[35m{'Anonymize': 1.0, 'Toxicity': 0.0, 'PromptInjection': 0.0, 'Secrets': 0.0}\u001b[0m\n",
       "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
       "HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
       "HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "\u001B[2m2024-05-10 15:03:55\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mReplaced placeholder with real value\u001B[0m \u001B[36mplaceholder\u001B[0m=\u001B[35m[REDACTED_EMAIL_ADDRESS_1]\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:55\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mReplaced placeholder with real value\u001B[0m \u001B[36mplaceholder\u001B[0m=\u001B[35m[REDACTED_PHONE_NUMBER_1]\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:55\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mReplaced placeholder with real value\u001B[0m \u001B[36mplaceholder\u001B[0m=\u001B[35m[REDACTED_EMAIL_ADDRESS_2]\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:55\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mReplaced placeholder with real value\u001B[0m \u001B[36mplaceholder\u001B[0m=\u001B[35m[REDACTED_PHONE_NUMBER_3]\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:55\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mReplaced placeholder with real value\u001B[0m \u001B[36mplaceholder\u001B[0m=\u001B[35m[REDACTED_PHONE_NUMBER_2]\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:55\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mReplaced placeholder with real value\u001B[0m \u001B[36mplaceholder\u001B[0m=\u001B[35m[REDACTED_PERSON_1]\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:55\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mReplaced placeholder with real value\u001B[0m \u001B[36mplaceholder\u001B[0m=\u001B[35m[REDACTED_EMAIL_ADDRESS_3]\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:55\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mReplaced placeholder with real value\u001B[0m \u001B[36mplaceholder\u001B[0m=\u001B[35m[REDACTED_PHONE_NUMBER_5]\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:55\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mReplaced placeholder with real value\u001B[0m \u001B[36mplaceholder\u001B[0m=\u001B[35m[REDACTED_PHONE_NUMBER_4]\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:55\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mReplaced placeholder with real value\u001B[0m \u001B[36mplaceholder\u001B[0m=\u001B[35m[REDACTED_PERSON_2]\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:55\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mScanner completed             \u001B[0m \u001B[36melapsed_time_seconds\u001B[0m=\u001B[35m0.003395\u001B[0m \u001B[36mis_valid\u001B[0m=\u001B[35mTrue\u001B[0m \u001B[36mscanner\u001B[0m=\u001B[35mDeanonymize\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:55\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mNot toxicity found in the text\u001B[0m \u001B[36mresults\u001B[0m=\u001B[35m[[{'label': 'toxicity', 'score': 0.0009320754325017333}, {'label': 'insult', 'score': 0.00037353255902417004}, {'label': 'male', 'score': 0.00013815340935252607}, {'label': 'female', 'score': 7.150010787881911e-05}, {'label': 'psychiatric_or_mental_illness', 'score': 7.00551099725999e-05}, {'label': 'obscene', 'score': 5.71139607927762e-05}, {'label': 'threat', 'score': 4.692306538345292e-05}, {'label': 'christian', 'score': 4.325451664044522e-05}, {'label': 'muslim', 'score': 4.2691128328442574e-05}, {'label': 'white', 'score': 3.643184754764661e-05}, {'label': 'identity_attack', 'score': 3.0974813853390515e-05}, {'label': 'black', 'score': 2.382797174504958e-05}, {'label': 'jewish', 'score': 2.066984961857088e-05}, {'label': 'sexual_explicit', 'score': 1.7647991626290604e-05}, {'label': 'homosexual_gay_or_lesbian', 'score': 1.5746270946692675e-05}, {'label': 'severe_toxicity', 'score': 9.646757916925708e-07}]]\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:55\u001B[0m [\u001B[32m\u001B[1mdebug    \u001B[0m] \u001B[1mScanner completed             \u001B[0m \u001B[36melapsed_time_seconds\u001B[0m=\u001B[35m0.29465\u001B[0m \u001B[36mis_valid\u001B[0m=\u001B[35mTrue\u001B[0m \u001B[36mscanner\u001B[0m=\u001B[35mToxicity\u001B[0m\n",
-      "\u001B[2m2024-05-10 15:03:55\u001B[0m [\u001B[32m\u001B[1minfo     \u001B[0m] \u001B[1mScanned output                \u001B[0m \u001B[36melapsed_time_seconds\u001B[0m=\u001B[35m0.298742\u001B[0m \u001B[36mscores\u001B[0m=\u001B[35m{'Deanonymize': 0.0, 'Toxicity': 0.0}\u001B[0m\n",
+      "\u001b[2m2024-05-10 15:03:55\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mReplaced placeholder with real value\u001b[0m \u001b[36mplaceholder\u001b[0m=\u001b[35m[REDACTED_EMAIL_ADDRESS_1]\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:55\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mReplaced placeholder with real value\u001b[0m \u001b[36mplaceholder\u001b[0m=\u001b[35m[REDACTED_PHONE_NUMBER_1]\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:55\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mReplaced placeholder with real value\u001b[0m \u001b[36mplaceholder\u001b[0m=\u001b[35m[REDACTED_EMAIL_ADDRESS_2]\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:55\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mReplaced placeholder with real value\u001b[0m \u001b[36mplaceholder\u001b[0m=\u001b[35m[REDACTED_PHONE_NUMBER_3]\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:55\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mReplaced placeholder with real value\u001b[0m \u001b[36mplaceholder\u001b[0m=\u001b[35m[REDACTED_PHONE_NUMBER_2]\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:55\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mReplaced placeholder with real value\u001b[0m \u001b[36mplaceholder\u001b[0m=\u001b[35m[REDACTED_PERSON_1]\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:55\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mReplaced placeholder with real value\u001b[0m \u001b[36mplaceholder\u001b[0m=\u001b[35m[REDACTED_EMAIL_ADDRESS_3]\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:55\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mReplaced placeholder with real value\u001b[0m \u001b[36mplaceholder\u001b[0m=\u001b[35m[REDACTED_PHONE_NUMBER_5]\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:55\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mReplaced placeholder with real value\u001b[0m \u001b[36mplaceholder\u001b[0m=\u001b[35m[REDACTED_PHONE_NUMBER_4]\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:55\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mReplaced placeholder with real value\u001b[0m \u001b[36mplaceholder\u001b[0m=\u001b[35m[REDACTED_PERSON_2]\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:55\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mScanner completed             \u001b[0m \u001b[36melapsed_time_seconds\u001b[0m=\u001b[35m0.003395\u001b[0m \u001b[36mis_valid\u001b[0m=\u001b[35mTrue\u001b[0m \u001b[36mscanner\u001b[0m=\u001b[35mDeanonymize\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:55\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mNot toxicity found in the text\u001b[0m \u001b[36mresults\u001b[0m=\u001b[35m[[{'label': 'toxicity', 'score': 0.0009320754325017333}, {'label': 'insult', 'score': 0.00037353255902417004}, {'label': 'male', 'score': 0.00013815340935252607}, {'label': 'female', 'score': 7.150010787881911e-05}, {'label': 'psychiatric_or_mental_illness', 'score': 7.00551099725999e-05}, {'label': 'obscene', 'score': 5.71139607927762e-05}, {'label': 'threat', 'score': 4.692306538345292e-05}, {'label': 'christian', 'score': 4.325451664044522e-05}, {'label': 'muslim', 'score': 4.2691128328442574e-05}, {'label': 'white', 'score': 3.643184754764661e-05}, {'label': 'identity_attack', 'score': 3.0974813853390515e-05}, {'label': 'black', 'score': 2.382797174504958e-05}, {'label': 'jewish', 'score': 2.066984961857088e-05}, {'label': 'sexual_explicit', 'score': 1.7647991626290604e-05}, {'label': 'homosexual_gay_or_lesbian', 'score': 1.5746270946692675e-05}, {'label': 'severe_toxicity', 'score': 9.646757916925708e-07}]]\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:55\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mScanner completed             \u001b[0m \u001b[36melapsed_time_seconds\u001b[0m=\u001b[35m0.29465\u001b[0m \u001b[36mis_valid\u001b[0m=\u001b[35mTrue\u001b[0m \u001b[36mscanner\u001b[0m=\u001b[35mToxicity\u001b[0m\n",
+      "\u001b[2m2024-05-10 15:03:55\u001b[0m [\u001b[32m\u001b[1minfo     \u001b[0m] \u001b[1mScanned output                \u001b[0m \u001b[36melapsed_time_seconds\u001b[0m=\u001b[35m0.298742\u001b[0m \u001b[36mscores\u001b[0m=\u001b[35m{'Deanonymize': 0.0, 'Toxicity': 0.0}\u001b[0m\n",
       "Jane Smith is the best.\n"
      ]
     }
    ],
-   "execution_count": 22
+   "source": [
+    "query_engine = index.as_query_engine(\n",
+    "    similarity_top_k=3, node_postprocessors=[llm_guard_postprocessor]\n",
+    ")\n",
+    "response = query_engine.query(\n",
+    "    \"I am screening candidates for adult caregiving opportunity. Please recommend me an experienced person. Return just a name\"\n",
+    ")\n",
+    "print(str(response))"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Let's also check the debug logs."
-   ],
+   "id": "de9488da7e1b4db",
    "metadata": {
     "collapsed": false
    },
-   "id": "de9488da7e1b4db"
+   "source": [
+    "Let's also check the debug logs."
+   ]
   },
   {
    "cell_type": "code",
-   "source": [
-    "print(llama_debug.get_events())\n",
-    "llama_debug.flush_event_logs()"
-   ],
+   "execution_count": 23,
+   "id": "8216cc5642777a40",
    "metadata": {
-    "collapsed": false,
     "ExecuteTime": {
      "end_time": "2024-05-10T13:03:55.610005Z",
      "start_time": "2024-05-10T13:03:55.604098Z"
-    }
+    },
+    "collapsed": false
    },
-   "id": "8216cc5642777a40",
    "outputs": [
     {
      "name": "stdout",
@@ -1047,17 +1054,20 @@
      ]
     }
    ],
-   "execution_count": 23
+   "source": [
+    "print(llama_debug.get_events())\n",
+    "llama_debug.flush_event_logs()"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Here we can see that no real name was passed to the LLM but only redacted one. However, output parser could deanonymize it."
-   ],
+   "id": "83186996a0231a18",
    "metadata": {
     "collapsed": false
    },
-   "id": "83186996a0231a18"
+   "source": [
+    "Here we can see that no real name was passed to the LLM but only redacted one. However, output parser could deanonymize it."
+   ]
   }
  ],
  "metadata": {

--- a/llm_guard/input_scanners/regex.py
+++ b/llm_guard/input_scanners/regex.py
@@ -79,14 +79,14 @@ class Regex(Scanner):
     def scan(self, prompt: str) -> tuple[str, bool, float]:
         text_replace_builder = TextReplaceBuilder(original_text=prompt)
         regex_counter = self._get_next_regex_counter() if self._vault else 1
-        
+
         # Collect all matches first
         all_matches = []
         for pattern in self._patterns:
             matches = self._match_type.match(pattern, prompt)
             if matches:
                 all_matches.extend(matches)
-        
+
         if not all_matches:
             if self._is_blocked:
                 LOGGER.debug("None of the patterns were found in the text")
@@ -106,7 +106,7 @@ class Regex(Scanner):
                     matched_text = text_replace_builder.get_text_in_position(
                         match.start(), match.end()
                     )
-                    
+
                     # Use vault-specific placeholders only when vault is provided
                     if self._vault:
                         placeholder = f"[REDACTED_REGEX_{regex_counter}]"
@@ -116,7 +116,7 @@ class Regex(Scanner):
                     else:
                         # Maintain backward compatibility
                         placeholder = "[REDACTED]"
-                    
+
                     text_replace_builder.replace_text_get_insertion_index(
                         placeholder,
                         match.start(),
@@ -127,12 +127,12 @@ class Regex(Scanner):
 
         LOGGER.debug("Patterns matched the text", num_matches=len(all_matches))
         return text_replace_builder.output_text, True, -1.0
-    
+
     def _get_next_regex_counter(self) -> int:
         """Get the next available counter for regex placeholders."""
         if not self._vault:
             return 1
-            
+
         existing_indices = set()
         for placeholder, _ in self._vault.get():
             if placeholder.startswith("[REDACTED_REGEX_") and placeholder.endswith("]"):
@@ -141,7 +141,7 @@ class Regex(Scanner):
                     existing_indices.add(index)
                 except ValueError:
                     pass
-        
+
         counter = 1
         while counter in existing_indices:
             counter += 1

--- a/llm_guard/input_scanners/regex.py
+++ b/llm_guard/input_scanners/regex.py
@@ -5,6 +5,7 @@ from typing import List, Pattern
 from presidio_anonymizer.core.text_replace_builder import TextReplaceBuilder
 
 from llm_guard.util import get_logger
+from llm_guard.vault import Vault
 
 from .base import Scanner
 
@@ -48,6 +49,7 @@ class Regex(Scanner):
         is_blocked: bool = True,
         match_type: MatchType | str = MatchType.ALL,
         redact: bool = True,
+        vault: Vault | None = None,
     ) -> None:
         """
         Initializes an instance of the Regex class.
@@ -57,6 +59,7 @@ class Regex(Scanner):
             is_blocked (bool): Whether the patterns are blocked or allowed.
             match_type (str): The type of match to use.
             redact (bool): Whether to redact the output or not.
+            vault (Vault): Optional vault instance to store redacted values for later deanonymization.
 
         Raises:
             ValueError: If no patterns are provided or both good and bad patterns are provided.
@@ -71,33 +74,75 @@ class Regex(Scanner):
         self._match_type = match_type
         self._is_blocked = is_blocked
         self._redact = redact
+        self._vault = vault
 
     def scan(self, prompt: str) -> tuple[str, bool, float]:
         text_replace_builder = TextReplaceBuilder(original_text=prompt)
+        regex_counter = self._get_next_regex_counter() if self._vault else 1
+        
+        # Collect all matches first
+        all_matches = []
         for pattern in self._patterns:
             matches = self._match_type.match(pattern, prompt)
-            if matches is None or len(matches) == 0:
-                continue
-
+            if matches:
+                all_matches.extend(matches)
+        
+        if not all_matches:
             if self._is_blocked:
-                LOGGER.warning("Pattern was detected in the text", pattern=pattern)
-
-                if self._redact:
-                    for match in matches:
-                        text_replace_builder.replace_text_get_insertion_index(
-                            "[REDACTED]",
-                            match.start(),
-                            match.end(),
-                        )
-
+                LOGGER.debug("None of the patterns were found in the text")
+                return text_replace_builder.output_text, True, -1.0
+            else:
+                LOGGER.warning("None of the patterns matched the text")
                 return text_replace_builder.output_text, False, 1.0
 
-            LOGGER.debug("Pattern matched the text", pattern=pattern)
-            return text_replace_builder.output_text, True, -1.0
+        # Sort matches by start position in reverse order for proper text replacement
+        all_matches.sort(key=lambda x: x.start(), reverse=True)
 
         if self._is_blocked:
-            LOGGER.debug("None of the patterns were found in the text")
-            return text_replace_builder.output_text, True, -1.0
+            LOGGER.warning("Patterns were detected in the text", num_matches=len(all_matches))
 
-        LOGGER.warning("None of the patterns matched the text")
-        return text_replace_builder.output_text, False, 1.0
+            if self._redact:
+                for match in all_matches:
+                    matched_text = text_replace_builder.get_text_in_position(
+                        match.start(), match.end()
+                    )
+                    
+                    # Use vault-specific placeholders only when vault is provided
+                    if self._vault:
+                        placeholder = f"[REDACTED_REGEX_{regex_counter}]"
+                        if not self._vault.placeholder_exists(placeholder):
+                            self._vault.append((placeholder, matched_text))
+                        regex_counter += 1
+                    else:
+                        # Maintain backward compatibility
+                        placeholder = "[REDACTED]"
+                    
+                    text_replace_builder.replace_text_get_insertion_index(
+                        placeholder,
+                        match.start(),
+                        match.end(),
+                    )
+
+            return text_replace_builder.output_text, False, 1.0
+
+        LOGGER.debug("Patterns matched the text", num_matches=len(all_matches))
+        return text_replace_builder.output_text, True, -1.0
+    
+    def _get_next_regex_counter(self) -> int:
+        """Get the next available counter for regex placeholders."""
+        if not self._vault:
+            return 1
+            
+        existing_indices = set()
+        for placeholder, _ in self._vault.get():
+            if placeholder.startswith("[REDACTED_REGEX_") and placeholder.endswith("]"):
+                try:
+                    index = int(placeholder.split("_")[-1][:-1])
+                    existing_indices.add(index)
+                except ValueError:
+                    pass
+        
+        counter = 1
+        while counter in existing_indices:
+            counter += 1
+        return counter

--- a/llm_guard/output_scanners/regex.py
+++ b/llm_guard/output_scanners/regex.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from llm_guard.input_scanners.regex import MatchType, Regex as InputRegex
+from llm_guard.vault import Vault
 
 from .base import Scanner
 
@@ -20,6 +21,7 @@ class Regex(Scanner):
         is_blocked: bool = True,
         match_type: MatchType | str = MatchType.SEARCH,
         redact=True,
+        vault: Vault | None = None,
     ) -> None:
         """
         Initializes an instance of the Regex class.
@@ -29,13 +31,14 @@ class Regex(Scanner):
             is_blocked (bool): Whether the patterns are blocked or allowed.
             match_type (str): The type of match to use. Can be either "search" or "fullmatch".
             redact (bool): Whether to redact the output or not.
+            vault (Vault): Optional vault instance to store redacted values for later deanonymization.
 
         Raises:
             ValueError: If no patterns provided or both good and bad patterns provided.
         """
 
         self._scanner = InputRegex(
-            patterns, is_blocked=is_blocked, match_type=match_type, redact=redact
+            patterns, is_blocked=is_blocked, match_type=match_type, redact=redact, vault=vault
         )
 
     def scan(self, prompt: str, output: str) -> tuple[str, bool, float]:

--- a/llm_guard_api/app/scanner.py
+++ b/llm_guard_api/app/scanner.py
@@ -115,6 +115,9 @@ def _get_input_scanner(
 
     if scanner_name == "Anonymize":
         scanner_config["vault"] = vault
+        
+    if scanner_name == "Regex":
+        scanner_config["vault"] = vault
 
     if scanner_name in [
         "Anonymize",
@@ -186,6 +189,9 @@ def _get_output_scanner(
         scanner_config = {}
 
     if scanner_name == "Deanonymize":
+        scanner_config["vault"] = vault
+        
+    if scanner_name == "Regex":
         scanner_config["vault"] = vault
 
     if scanner_name in [

--- a/llm_guard_api/app/scanner.py
+++ b/llm_guard_api/app/scanner.py
@@ -115,7 +115,7 @@ def _get_input_scanner(
 
     if scanner_name == "Anonymize":
         scanner_config["vault"] = vault
-        
+
     if scanner_name == "Regex":
         scanner_config["vault"] = vault
 
@@ -190,7 +190,7 @@ def _get_output_scanner(
 
     if scanner_name == "Deanonymize":
         scanner_config["vault"] = vault
-        
+
     if scanner_name == "Regex":
         scanner_config["vault"] = vault
 

--- a/tests/input_scanners/test_anonymize.py
+++ b/tests/input_scanners/test_anonymize.py
@@ -324,9 +324,9 @@ def test_patterns():
 
         for example in group.get("examples", []):
             for expression in group.get("expressions", []):
-                assert re.search(expression, example) is not None, (
-                    f"Test for {name} failed. No match found for example: {example}"
-                )
+                assert (
+                    re.search(expression, example) is not None
+                ), f"Test for {name} failed. No match found for example: {example}"
 
 
 def test_placeholder_consistency():
@@ -359,15 +359,15 @@ def test_placeholder_consistency():
     email_placeholders = [p for p, v in vault_contents if v == "john@example.com"]
 
     # Each unique value should have exactly one placeholder
-    assert len(john_placeholders) == 1, (
-        f"John Smith should have 1 placeholder, got {len(john_placeholders)}: {john_placeholders}"
-    )
-    assert len(mary_placeholders) == 1, (
-        f"Mary Johnson should have 1 placeholder, got {len(mary_placeholders)}: {mary_placeholders}"
-    )
-    assert len(email_placeholders) == 1, (
-        f"john@example.com should have 1 placeholder, got {len(email_placeholders)}: {email_placeholders}"
-    )
+    assert (
+        len(john_placeholders) == 1
+    ), f"John Smith should have 1 placeholder, got {len(john_placeholders)}: {john_placeholders}"
+    assert (
+        len(mary_placeholders) == 1
+    ), f"Mary Johnson should have 1 placeholder, got {len(mary_placeholders)}: {mary_placeholders}"
+    assert (
+        len(email_placeholders) == 1
+    ), f"john@example.com should have 1 placeholder, got {len(email_placeholders)}: {email_placeholders}"
 
     # Verify specific placeholder assignments
     john_placeholder = john_placeholders[0]
@@ -375,15 +375,15 @@ def test_placeholder_consistency():
     email_placeholder = email_placeholders[0]
 
     # John should be PERSON_1, Mary should be PERSON_2, email should be EMAIL_ADDRESS_1
-    assert john_placeholder == "[REDACTED_PERSON_1]", (
-        f"Expected [REDACTED_PERSON_1], got {john_placeholder}"
-    )
-    assert mary_placeholder == "[REDACTED_PERSON_2]", (
-        f"Expected [REDACTED_PERSON_2], got {mary_placeholder}"
-    )
-    assert email_placeholder == "[REDACTED_EMAIL_ADDRESS_1]", (
-        f"Expected [REDACTED_EMAIL_ADDRESS_1], got {email_placeholder}"
-    )
+    assert (
+        john_placeholder == "[REDACTED_PERSON_1]"
+    ), f"Expected [REDACTED_PERSON_1], got {john_placeholder}"
+    assert (
+        mary_placeholder == "[REDACTED_PERSON_2]"
+    ), f"Expected [REDACTED_PERSON_2], got {mary_placeholder}"
+    assert (
+        email_placeholder == "[REDACTED_EMAIL_ADDRESS_1]"
+    ), f"Expected [REDACTED_EMAIL_ADDRESS_1], got {email_placeholder}"
 
     # Verify results contain consistent placeholders
     assert john_placeholder in result1


### PR DESCRIPTION
Similar to the Anonymizer scanner, the Regex scanner now supports storing redacted values in a vault for later deanonymization. When a vault is provided, matched patterns are replaced with unique placeholders like [REDACTED_REGEX_1], [REDACTED_REGEX_2], etc., and the original values are stored in the vault.

Key changes:
- Add optional vault parameter to both input and output Regex scanners
- Store matched regex patterns in vault with unique indexed placeholders
- Maintain backward compatibility when no vault is provided (uses [REDACTED])
- Update llm_guard_api scanner configuration to pass vault to Regex scanners
- Implement proper counter management to avoid placeholder conflicts

## Change Description

Describe your changes

## Issue reference

This PR fixes issue #XX

## Checklist

- [x] I have reviewed the [contribution guidelines](../CONTRIBUTING.md)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
