### PR TITLE
Upgrade package transformers due to vulnerability

### DIFF
--- a/llm_guard/input_scanners/anonymize_helpers/transformers_recognizer.py
+++ b/llm_guard/input_scanners/anonymize_helpers/transformers_recognizer.py
@@ -139,8 +139,8 @@ class TransformersRecognizer(EntityRecognizer):
         self.model.pipeline_kwargs["ignore_labels"] = self.ignore_labels
 
         transformers = cast("transformers", lazy_load_dep("transformers"))
-        self.pipeline = transformers.pipelines.pipeline(
-            "ner",
+        self.pipeline = transformers.pipelines.pipeline(  # type: ignore[arg-type]
+            "ner",  # type: ignore[arg-type]
             model=tf_model,
             tokenizer=tf_tokenizer,
             **self.model.pipeline_kwargs,

--- a/llm_guard/output_scanners/relevance.py
+++ b/llm_guard/output_scanners/relevance.py
@@ -91,16 +91,20 @@ class Relevance(Scanner):
                 ),
             )
             assert model.onnx_path is not None
-            self._model = optimum_onnxruntime.ORTModelForFeatureExtraction.from_pretrained(
-                model.onnx_path,
-                export=False,
-                subfolder=model.onnx_subfolder,
-                file_name=model.onnx_filename,
-                revision=model.onnx_revision,
-                provider=(
+            onnx_kwargs = {
+                "export": False,
+                "subfolder": model.onnx_subfolder,
+                "file_name": model.onnx_filename,
+                "provider": (
                     "CUDAExecutionProvider" if device().type == "cuda" else "CPUExecutionProvider"
                 ),
                 **model.kwargs,
+            }
+            if model.onnx_revision is not None:
+                onnx_kwargs["revision"] = model.onnx_revision
+            self._model = optimum_onnxruntime.ORTModelForFeatureExtraction.from_pretrained(
+                model.onnx_path,
+                **onnx_kwargs,
             )
             LOGGER.debug("Initialized ONNX model", model=model, device=device())
         else:

--- a/llm_guard/util.py
+++ b/llm_guard/util.py
@@ -198,7 +198,7 @@ def truncate_tokens_head_tail(tokens, max_length=512, head_length=128, tail_leng
 
 
 url_pattern = re.compile(
-    r"http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+"
+    r"http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+"
 )
 
 
@@ -225,7 +225,7 @@ def remove_markdown(text):
     clean_text = text
     for pattern in patterns:
         # Use substitution to preserve the text inside ** and *
-        if "([^\*]+)" in pattern:
+        if r"([^\*]+)" in pattern:
             clean_text = re.sub(pattern, r"\1", clean_text)
         else:
             clean_text = re.sub(pattern, "", clean_text)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "regex==2024.11.6",
   "tiktoken>=0.9,<1.0",
   "torch>=2.4.0",
-  "transformers==4.51.3",
+  "transformers==4.53.0",
   "structlog>=24"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,10 +35,10 @@ dependencies = [
 
 [project.optional-dependencies]
 onnxruntime = [
-  "optimum[onnxruntime]==1.25.2",
+  "optimum[onnxruntime]==1.27.0",
 ]
 onnxruntime-gpu = [
-  "optimum[onnxruntime-gpu]==1.25.2",
+  "optimum[onnxruntime-gpu]==1.27.0",
 ]
 docs-dev = [
   "mkdocs>=1.6,<2",


### PR DESCRIPTION
## Change Description

This PR upgrades the vulnerable package `transformers` to **4.53.0.**.
According to `uv-secure`:
```
┏━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
┃ Package         ┃ Version       ┃ Vulnerability ID          ┃ Fix Versions   ┃
┡━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━┩
│ transformers    │ 4.51.3        │ GHSA-phhr-52qp-3mj4       │ 4.52.1         │
│ transformers    │ 4.51.3        │ GHSA-37mw-44qp-f5jm       │ 4.52.1         │
│ transformers    │ 4.51.3        │ GHSA-9356-575x-2w9m       │ 4.53.0         │
│ transformers    │ 4.51.3        │ GHSA-59p9-h35m-wg4g       │ 4.53.0         │
│ transformers    │ 4.51.3        │ GHSA-rcv9-qm8p-9p6j       │ 4.53.0         │
│ transformers    │ 4.51.3        │ GHSA-4w7r-h757-3r74       │ 4.53.0         │
└─────────────────┴───────────────┴───────────────────────────┴────────────────┘ 
```
It required to bump the version of `optimum` and `optimum[onnxruntime]` to **1.27.0**

After pre-commit check failures, claude fixed it for me:
```
  Fixed Type Errors

  1. transformers_recognizer.py (lines 142-143)

  - Issue: Type mismatch between "ner" task and the expected "zero-shot-object-detection" literal type
  - Fix: Added # type: ignore[arg-type] comments to suppress the type checker error since this is a valid use case with dynamic string types from the transformers library

  2. relevance.py (line 99)

  - Issue: model.onnx_revision is str | None but from_pretrained() expects str
  - Fix: Build the kwargs dictionary conditionally, only adding the revision parameter when it's not None

  3. util.py (line 228)

  - Issue: Invalid escape sequence \* in non-raw string literal
  - Fix: Changed "([^\*]+)" to r"([^\*]+)" to use a raw string
```

## Issue reference

No issue was detected with this

## Checklist

- [x] I have reviewed the [contribution guidelines](../CONTRIBUTING.md)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
