### PR TITLE
Feature/feedback capture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ cython_debug/
 
 .vscode
 .benchmarks
+
+# Analysis workspace
+SelfAnalysis/

--- a/llm_guard/feedback/__init__.py
+++ b/llm_guard/feedback/__init__.py
@@ -1,0 +1,26 @@
+"""
+Feedback capture module for llm-guard.
+
+This module provides data models and collection logic for structured feedback
+on scanner results. It is designed to be fully optional and privacy-first.
+
+Phase 1: Data models (FeedbackRecord, FeedbackCollectorConfig)
+Phase 2: Collector and storage backends
+Phase 3: Wrapper functions (in .wrapper module)
+"""
+
+from .collector import FeedbackCollector
+from .model import FeedbackCollectorConfig, FeedbackRecord
+from .storage import FileStorage, InMemoryStorage, StorageBackend
+
+# Note: wrapper module is available but not re-exported
+# Use: from llm_guard.feedback.wrapper import scan_prompt_with_feedback
+
+__all__ = [
+    "FeedbackRecord",
+    "FeedbackCollectorConfig",
+    "FeedbackCollector",
+    "StorageBackend",
+    "InMemoryStorage",
+    "FileStorage",
+]

--- a/llm_guard/feedback/collector.py
+++ b/llm_guard/feedback/collector.py
@@ -19,19 +19,19 @@ from .storage import FileStorage, InMemoryStorage, StorageBackend
 class FeedbackCollector:
     """
     Collector for feedback on scanner results.
-    
+
     This class provides methods to record scan results and collect user feedback
     on false positives and false negatives. It is designed to be:
     - Fully opt-in (disabled by default)
     - Privacy-first (no raw text by default)
     - Non-invasive (no impact on scanning)
-    
+
     When disabled (config.enabled=False), all methods are no-ops with minimal overhead.
-    
+
     Args:
         config: Configuration for feedback collection behavior.
                 If not provided, uses default (disabled) configuration.
-    
+
     Example:
         >>> config = FeedbackCollectorConfig(enabled=True, privacy_level=0)
         >>> collector = FeedbackCollector(config)
@@ -42,17 +42,17 @@ class FeedbackCollector:
         ... )
         >>> collector.report_feedback(record_id, "false_positive", ["Toxicity"])
     """
-    
+
     def __init__(self, config: FeedbackCollectorConfig | None = None):
         self._config = config or FeedbackCollectorConfig()
-        
+
         # Initialize storage backend based on configuration
         if self._config.enabled:
             self._storage = self._create_storage()
         else:
             # When disabled, don't even create storage
             self._storage = None
-    
+
     def _create_storage(self) -> StorageBackend:
         """Create storage backend based on configuration."""
         if self._config.storage_backend == "file":
@@ -64,7 +64,7 @@ class FeedbackCollector:
         else:
             # Custom backend not supported in Phase 2
             raise ValueError(f"Unsupported storage backend: {self._config.storage_backend}")
-    
+
     def record_scan(
         self,
         scan_type: str,
@@ -75,10 +75,10 @@ class FeedbackCollector:
     ) -> str | None:
         """
         Record a scan result for potential feedback.
-        
+
         This method creates a FeedbackRecord and stores it according to the
         configured privacy level and storage backend.
-        
+
         Args:
             scan_type: Type of scan ("prompt" or "output").
             scanner_results: Dictionary of scanner results.
@@ -86,36 +86,37 @@ class FeedbackCollector:
             prompt: The input prompt (optional, used for hashing/sampling based on privacy_level).
             output: The output text (optional, for output scans).
             metadata: Additional metadata (optional, currently unused).
-        
+
         Returns:
             Record ID if recorded successfully, None if skipped (disabled or sampling).
         """
         # Fast path: if disabled, return immediately
         if not self._config.enabled:
             return None
-        
+
         # Check if we should record based on include_correct setting
         # Only skip if ALL scanners passed AND include_correct is False
-        any_failed = any(
-            not result.get("valid", True) 
-            for result in scanner_results.values()
-        )
+        any_failed = any(not result.get("valid", True) for result in scanner_results.values())
         if not any_failed and not self._config.include_correct:
             return None
-        
+
         # Apply sampling rate
         if self._config.sampling_rate < 1.0:
             if random.random() > self._config.sampling_rate:
                 return None
-        
+
         # Generate record ID
         record_id = str(uuid.uuid4())
-        
+
         # Create record with privacy-appropriate data
+        from typing import cast
+
+        from .model import ScanType
+
         record = FeedbackRecord(
             record_id=record_id,
             timestamp=datetime.now(),
-            scan_type=scan_type,
+            scan_type=cast(ScanType, scan_type),
             scanner_results=scanner_results,
             prompt_hash=self._hash_text(prompt) if prompt else None,
             output_hash=self._hash_text(output) if output else None,
@@ -125,13 +126,13 @@ class FeedbackCollector:
             prompt_sample=self._get_text_sample(prompt) if prompt else None,
             output_sample=self._get_text_sample(output) if output else None,
         )
-        
+
         # Store the record
         if self._storage:
             self._storage.add(record)
-        
+
         return record_id
-    
+
     def report_feedback(
         self,
         record_id: str,
@@ -141,89 +142,93 @@ class FeedbackCollector:
     ) -> bool:
         """
         Add user feedback to an existing record.
-        
+
         This method updates a previously recorded scan with user feedback
         about false positives or false negatives.
-        
+
         Args:
             record_id: ID of the record to update.
             feedback_type: Type of feedback ("false_positive", "false_negative", or "correct").
             reported_scanners: List of scanner names being reported.
             comment: Optional free-text comment from user.
-        
+
         Returns:
             True if feedback was added successfully, False otherwise.
         """
         # Fast path: if disabled, return immediately
         if not self._config.enabled or not self._storage:
             return False
-        
+
         # Find the record
         records = self._storage.list()
         for record in records:
             if record.record_id == record_id:
+                from typing import cast
+
+                from .model import FeedbackType
+
                 # Update the record
-                record.feedback_type = feedback_type
+                record.feedback_type = cast(FeedbackType, feedback_type)
                 record.reported_scanners = reported_scanners
                 record.user_comment = comment
                 return True
-        
+
         return False
-    
+
     def get_records(self, filter_by: dict | None = None) -> list[FeedbackRecord]:
         """
         Retrieve feedback records with optional filtering.
-        
+
         Args:
             filter_by: Optional dictionary of filters (currently unused in Phase 2).
-        
+
         Returns:
             List of feedback records.
         """
         # Fast path: if disabled, return empty list
         if not self._config.enabled or not self._storage:
             return []
-        
+
         records = self._storage.list()
-        
+
         # Simple filtering (Phase 2: basic implementation)
         if filter_by:
             filtered = []
             for record in records:
                 match = True
-                
+
                 if "feedback_type" in filter_by:
                     if record.feedback_type != filter_by["feedback_type"]:
                         match = False
-                
+
                 if "scan_type" in filter_by:
                     if record.scan_type != filter_by["scan_type"]:
                         match = False
-                
+
                 if match:
                     filtered.append(record)
-            
+
             return filtered
-        
+
         return records
-    
+
     def clear_records(self) -> int:
         """
         Clear all records.
-        
+
         Returns:
             Count of cleared records.
         """
         # Fast path: if disabled, return 0
         if not self._config.enabled or not self._storage:
             return 0
-        
+
         return self._storage.clear()
-    
+
     def get_stats(self) -> dict:
         """
         Get summary statistics about collected feedback.
-        
+
         Returns:
             Dictionary with statistics.
         """
@@ -233,9 +238,9 @@ class FeedbackCollector:
                 "total_records": 0,
                 "enabled": False,
             }
-        
+
         records = self._storage.list()
-        
+
         # Count feedback types
         feedback_counts = {
             "false_positive": 0,
@@ -243,13 +248,15 @@ class FeedbackCollector:
             "correct": 0,
             "no_feedback": 0,
         }
-        
+
         for record in records:
             if record.feedback_type:
-                feedback_counts[record.feedback_type] = feedback_counts.get(record.feedback_type, 0) + 1
+                feedback_counts[record.feedback_type] = (
+                    feedback_counts.get(record.feedback_type, 0) + 1
+                )
             else:
                 feedback_counts["no_feedback"] += 1
-        
+
         return {
             "total_records": len(records),
             "enabled": self._config.enabled,
@@ -257,33 +264,34 @@ class FeedbackCollector:
             "storage_backend": self._config.storage_backend,
             "feedback_counts": feedback_counts,
         }
-    
+
     def _hash_text(self, text: str | None) -> str | None:
         """Generate SHA256 hash of text."""
         if text is None:
             return None
-        return hashlib.sha256(text.encode('utf-8')).hexdigest()
-    
+        return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
     def _get_text_sample(self, text: str | None) -> str | None:
         """Get text sample based on privacy level."""
         if text is None:
             return None
-        
+
         # Privacy level 0: no samples
         if self._config.privacy_level == 0:
             return None
-        
+
         # Privacy level 1: first 50 characters
         if self._config.privacy_level == 1:
             return text[:50] if len(text) > 50 else text
-        
+
         # Privacy level 2+: full text (anonymization would be in Phase 3+)
         return text
-    
+
     def _get_llm_guard_version(self) -> str:
         """Get llm-guard version."""
         try:
             import llm_guard
-            return getattr(llm_guard, '__version__', 'unknown')
+
+            return getattr(llm_guard, "__version__", "unknown")
         except ImportError:
-            return 'unknown'
+            return "unknown"

--- a/llm_guard/feedback/collector.py
+++ b/llm_guard/feedback/collector.py
@@ -1,0 +1,289 @@
+"""
+Feedback collector for llm-guard scanner results.
+
+This module provides the FeedbackCollector class for collecting structured
+feedback on scanner results. It is designed to be fully optional and privacy-first.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import random
+import uuid
+from datetime import datetime
+
+from .model import FeedbackCollectorConfig, FeedbackRecord
+from .storage import FileStorage, InMemoryStorage, StorageBackend
+
+
+class FeedbackCollector:
+    """
+    Collector for feedback on scanner results.
+    
+    This class provides methods to record scan results and collect user feedback
+    on false positives and false negatives. It is designed to be:
+    - Fully opt-in (disabled by default)
+    - Privacy-first (no raw text by default)
+    - Non-invasive (no impact on scanning)
+    
+    When disabled (config.enabled=False), all methods are no-ops with minimal overhead.
+    
+    Args:
+        config: Configuration for feedback collection behavior.
+                If not provided, uses default (disabled) configuration.
+    
+    Example:
+        >>> config = FeedbackCollectorConfig(enabled=True, privacy_level=0)
+        >>> collector = FeedbackCollector(config)
+        >>> record_id = collector.record_scan(
+        ...     scan_type="prompt",
+        ...     scanner_results={"Toxicity": {"valid": True, "score": 0.1}},
+        ...     prompt="Hello world"
+        ... )
+        >>> collector.report_feedback(record_id, "false_positive", ["Toxicity"])
+    """
+    
+    def __init__(self, config: FeedbackCollectorConfig | None = None):
+        self._config = config or FeedbackCollectorConfig()
+        
+        # Initialize storage backend based on configuration
+        if self._config.enabled:
+            self._storage = self._create_storage()
+        else:
+            # When disabled, don't even create storage
+            self._storage = None
+    
+    def _create_storage(self) -> StorageBackend:
+        """Create storage backend based on configuration."""
+        if self._config.storage_backend == "file":
+            if self._config.storage_path is None:
+                raise ValueError("storage_path required for file backend")
+            return FileStorage(self._config.storage_path)
+        elif self._config.storage_backend == "memory":
+            return InMemoryStorage(self._config.max_records)
+        else:
+            # Custom backend not supported in Phase 2
+            raise ValueError(f"Unsupported storage backend: {self._config.storage_backend}")
+    
+    def record_scan(
+        self,
+        scan_type: str,
+        scanner_results: dict[str, dict[str, bool | float]],
+        prompt: str | None = None,
+        output: str | None = None,
+        metadata: dict | None = None,
+    ) -> str | None:
+        """
+        Record a scan result for potential feedback.
+        
+        This method creates a FeedbackRecord and stores it according to the
+        configured privacy level and storage backend.
+        
+        Args:
+            scan_type: Type of scan ("prompt" or "output").
+            scanner_results: Dictionary of scanner results.
+                           Expected format: {scanner_name: {"valid": bool, "score": float}}
+            prompt: The input prompt (optional, used for hashing/sampling based on privacy_level).
+            output: The output text (optional, for output scans).
+            metadata: Additional metadata (optional, currently unused).
+        
+        Returns:
+            Record ID if recorded successfully, None if skipped (disabled or sampling).
+        """
+        # Fast path: if disabled, return immediately
+        if not self._config.enabled:
+            return None
+        
+        # Check if we should record based on include_correct setting
+        # Only skip if ALL scanners passed AND include_correct is False
+        any_failed = any(
+            not result.get("valid", True) 
+            for result in scanner_results.values()
+        )
+        if not any_failed and not self._config.include_correct:
+            return None
+        
+        # Apply sampling rate
+        if self._config.sampling_rate < 1.0:
+            if random.random() > self._config.sampling_rate:
+                return None
+        
+        # Generate record ID
+        record_id = str(uuid.uuid4())
+        
+        # Create record with privacy-appropriate data
+        record = FeedbackRecord(
+            record_id=record_id,
+            timestamp=datetime.now(),
+            scan_type=scan_type,
+            scanner_results=scanner_results,
+            prompt_hash=self._hash_text(prompt) if prompt else None,
+            output_hash=self._hash_text(output) if output else None,
+            prompt_length=len(prompt) if prompt else 0,
+            output_length=len(output) if output else None,
+            llm_guard_version=self._get_llm_guard_version(),
+            prompt_sample=self._get_text_sample(prompt) if prompt else None,
+            output_sample=self._get_text_sample(output) if output else None,
+        )
+        
+        # Store the record
+        if self._storage:
+            self._storage.add(record)
+        
+        return record_id
+    
+    def report_feedback(
+        self,
+        record_id: str,
+        feedback_type: str,
+        reported_scanners: list[str],
+        comment: str | None = None,
+    ) -> bool:
+        """
+        Add user feedback to an existing record.
+        
+        This method updates a previously recorded scan with user feedback
+        about false positives or false negatives.
+        
+        Args:
+            record_id: ID of the record to update.
+            feedback_type: Type of feedback ("false_positive", "false_negative", or "correct").
+            reported_scanners: List of scanner names being reported.
+            comment: Optional free-text comment from user.
+        
+        Returns:
+            True if feedback was added successfully, False otherwise.
+        """
+        # Fast path: if disabled, return immediately
+        if not self._config.enabled or not self._storage:
+            return False
+        
+        # Find the record
+        records = self._storage.list()
+        for record in records:
+            if record.record_id == record_id:
+                # Update the record
+                record.feedback_type = feedback_type
+                record.reported_scanners = reported_scanners
+                record.user_comment = comment
+                return True
+        
+        return False
+    
+    def get_records(self, filter_by: dict | None = None) -> list[FeedbackRecord]:
+        """
+        Retrieve feedback records with optional filtering.
+        
+        Args:
+            filter_by: Optional dictionary of filters (currently unused in Phase 2).
+        
+        Returns:
+            List of feedback records.
+        """
+        # Fast path: if disabled, return empty list
+        if not self._config.enabled or not self._storage:
+            return []
+        
+        records = self._storage.list()
+        
+        # Simple filtering (Phase 2: basic implementation)
+        if filter_by:
+            filtered = []
+            for record in records:
+                match = True
+                
+                if "feedback_type" in filter_by:
+                    if record.feedback_type != filter_by["feedback_type"]:
+                        match = False
+                
+                if "scan_type" in filter_by:
+                    if record.scan_type != filter_by["scan_type"]:
+                        match = False
+                
+                if match:
+                    filtered.append(record)
+            
+            return filtered
+        
+        return records
+    
+    def clear_records(self) -> int:
+        """
+        Clear all records.
+        
+        Returns:
+            Count of cleared records.
+        """
+        # Fast path: if disabled, return 0
+        if not self._config.enabled or not self._storage:
+            return 0
+        
+        return self._storage.clear()
+    
+    def get_stats(self) -> dict:
+        """
+        Get summary statistics about collected feedback.
+        
+        Returns:
+            Dictionary with statistics.
+        """
+        # Fast path: if disabled, return empty stats
+        if not self._config.enabled or not self._storage:
+            return {
+                "total_records": 0,
+                "enabled": False,
+            }
+        
+        records = self._storage.list()
+        
+        # Count feedback types
+        feedback_counts = {
+            "false_positive": 0,
+            "false_negative": 0,
+            "correct": 0,
+            "no_feedback": 0,
+        }
+        
+        for record in records:
+            if record.feedback_type:
+                feedback_counts[record.feedback_type] = feedback_counts.get(record.feedback_type, 0) + 1
+            else:
+                feedback_counts["no_feedback"] += 1
+        
+        return {
+            "total_records": len(records),
+            "enabled": self._config.enabled,
+            "privacy_level": self._config.privacy_level,
+            "storage_backend": self._config.storage_backend,
+            "feedback_counts": feedback_counts,
+        }
+    
+    def _hash_text(self, text: str | None) -> str | None:
+        """Generate SHA256 hash of text."""
+        if text is None:
+            return None
+        return hashlib.sha256(text.encode('utf-8')).hexdigest()
+    
+    def _get_text_sample(self, text: str | None) -> str | None:
+        """Get text sample based on privacy level."""
+        if text is None:
+            return None
+        
+        # Privacy level 0: no samples
+        if self._config.privacy_level == 0:
+            return None
+        
+        # Privacy level 1: first 50 characters
+        if self._config.privacy_level == 1:
+            return text[:50] if len(text) > 50 else text
+        
+        # Privacy level 2+: full text (anonymization would be in Phase 3+)
+        return text
+    
+    def _get_llm_guard_version(self) -> str:
+        """Get llm-guard version."""
+        try:
+            import llm_guard
+            return getattr(llm_guard, '__version__', 'unknown')
+        except ImportError:
+            return 'unknown'

--- a/llm_guard/feedback/model.py
+++ b/llm_guard/feedback/model.py
@@ -27,10 +27,10 @@ StorageBackend = Literal["memory", "file", "custom"]
 class FeedbackRecord:
     """
     Represents a single feedback event for a scanner result.
-    
+
     This dataclass stores metadata about a scan and optional user feedback.
     By default (privacy_level=0), no raw prompt or output text is stored.
-    
+
     Attributes:
         record_id: Unique identifier for this feedback record (UUID recommended).
         timestamp: When this feedback was recorded.
@@ -49,30 +49,30 @@ class FeedbackRecord:
         prompt_sample: Optional text sample or anonymized prompt (privacy level 1+).
         output_sample: Optional text sample or anonymized output (privacy level 1+).
     """
-    
+
     # Identifiers
     record_id: str
     timestamp: datetime
-    
+
     # Scan context
     scan_type: ScanType
     scanner_results: dict[str, dict[str, bool | float]]
-    
+
     # Feedback (optional, can be added after initial recording)
     feedback_type: FeedbackType | None = None
     reported_scanners: list[str] = dataclasses.field(default_factory=list)
     user_comment: str | None = None
-    
+
     # Privacy-safe metadata (always collected)
     prompt_hash: str | None = None
     output_hash: str | None = None
     prompt_length: int = 0
     output_length: int | None = None
-    
+
     # Scanner metadata
     scanner_versions: dict[str, str] = dataclasses.field(default_factory=dict)
     llm_guard_version: str = ""
-    
+
     # Optional text data (requires privacy_level > 0)
     prompt_sample: str | None = None
     output_sample: str | None = None
@@ -82,10 +82,10 @@ class FeedbackRecord:
 class FeedbackCollectorConfig:
     """
     Configuration for feedback collection behavior.
-    
+
     This dataclass defines how feedback should be collected, stored, and what
     data should be included based on privacy preferences.
-    
+
     Attributes:
         enabled: Master switch for feedback collection. When False, all collection
                 is disabled (no-op behavior).
@@ -105,36 +105,36 @@ class FeedbackCollectorConfig:
         auto_flush: Whether to automatically flush records to storage when
                    max_records is reached. Requires storage_backend="file".
     """
-    
+
     # Core settings
     enabled: bool = False
     privacy_level: int = 0
-    
+
     # Storage settings
     storage_backend: StorageBackend = "memory"
     storage_path: str | None = None
-    
+
     # Performance and capacity settings
     max_records: int = 1000
     sampling_rate: float = 1.0
-    
+
     # Collection behavior
     include_correct: bool = False
     auto_flush: bool = False
-    
+
     def __post_init__(self) -> None:
         """Validate configuration values."""
         if not 0 <= self.privacy_level <= 3:
             raise ValueError(f"privacy_level must be 0-3, got {self.privacy_level}")
-        
+
         if not 0.0 <= self.sampling_rate <= 1.0:
             raise ValueError(f"sampling_rate must be 0.0-1.0, got {self.sampling_rate}")
-        
+
         if self.max_records < 1:
             raise ValueError(f"max_records must be >= 1, got {self.max_records}")
-        
+
         if self.storage_backend == "file" and self.storage_path is None:
             raise ValueError("storage_path is required when storage_backend='file'")
-        
+
         if self.auto_flush and self.storage_backend != "file":
             raise ValueError("auto_flush requires storage_backend='file'")

--- a/llm_guard/feedback/model.py
+++ b/llm_guard/feedback/model.py
@@ -1,0 +1,140 @@
+"""
+Data models for feedback capture.
+
+This module defines the core data structures for collecting feedback on scanner results.
+All models are designed to be privacy-first with configurable privacy levels.
+
+Privacy Levels:
+    0 (Default): Metadata only (hashes, lengths, scores) - no raw text
+    1: Include text samples (first N characters)
+    2: Include anonymized text (PII removed)
+    3: Include full raw text (requires explicit user consent)
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from datetime import datetime
+from typing import Literal
+
+# Type aliases for clarity
+FeedbackType = Literal["false_positive", "false_negative", "correct"]
+ScanType = Literal["prompt", "output"]
+StorageBackend = Literal["memory", "file", "custom"]
+
+
+@dataclasses.dataclass
+class FeedbackRecord:
+    """
+    Represents a single feedback event for a scanner result.
+    
+    This dataclass stores metadata about a scan and optional user feedback.
+    By default (privacy_level=0), no raw prompt or output text is stored.
+    
+    Attributes:
+        record_id: Unique identifier for this feedback record (UUID recommended).
+        timestamp: When this feedback was recorded.
+        scan_type: Type of scan ("prompt" or "output").
+        scanner_results: Dictionary mapping scanner names to their results.
+                        Expected format: {scanner_name: {"valid": bool, "score": float}}
+        feedback_type: Type of feedback provided by user.
+        reported_scanners: List of scanner names being reported on.
+        user_comment: Optional free-text comment from user.
+        prompt_hash: SHA256 hash of the prompt (for identification without storage).
+        output_hash: SHA256 hash of the output (for output scans only).
+        prompt_length: Character count of the prompt.
+        output_length: Character count of the output (for output scans only).
+        scanner_versions: Dictionary mapping scanner names to version/config identifiers.
+        llm_guard_version: Version of llm-guard package at time of recording.
+        prompt_sample: Optional text sample or anonymized prompt (privacy level 1+).
+        output_sample: Optional text sample or anonymized output (privacy level 1+).
+    """
+    
+    # Identifiers
+    record_id: str
+    timestamp: datetime
+    
+    # Scan context
+    scan_type: ScanType
+    scanner_results: dict[str, dict[str, bool | float]]
+    
+    # Feedback (optional, can be added after initial recording)
+    feedback_type: FeedbackType | None = None
+    reported_scanners: list[str] = dataclasses.field(default_factory=list)
+    user_comment: str | None = None
+    
+    # Privacy-safe metadata (always collected)
+    prompt_hash: str | None = None
+    output_hash: str | None = None
+    prompt_length: int = 0
+    output_length: int | None = None
+    
+    # Scanner metadata
+    scanner_versions: dict[str, str] = dataclasses.field(default_factory=dict)
+    llm_guard_version: str = ""
+    
+    # Optional text data (requires privacy_level > 0)
+    prompt_sample: str | None = None
+    output_sample: str | None = None
+
+
+@dataclasses.dataclass
+class FeedbackCollectorConfig:
+    """
+    Configuration for feedback collection behavior.
+    
+    This dataclass defines how feedback should be collected, stored, and what
+    data should be included based on privacy preferences.
+    
+    Attributes:
+        enabled: Master switch for feedback collection. When False, all collection
+                is disabled (no-op behavior).
+        privacy_level: Controls what data is collected (0-3).
+                      0 = metadata only (default, most private)
+                      1 = include text samples (first N chars)
+                      2 = include anonymized text (PII removed)
+                      3 = include full raw text (requires explicit consent)
+        storage_backend: Where to store feedback records.
+        storage_path: File path for file-based storage (required if backend="file").
+        max_records: Maximum number of records to keep in memory. When exceeded,
+                    oldest records are dropped (FIFO) unless auto_flush is enabled.
+        sampling_rate: Fraction of scans to record (0.0-1.0). Use <1.0 for
+                      high-volume scenarios to reduce overhead.
+        include_correct: Whether to record feedback for scans that passed all
+                        scanners. Default False (only record failures).
+        auto_flush: Whether to automatically flush records to storage when
+                   max_records is reached. Requires storage_backend="file".
+    """
+    
+    # Core settings
+    enabled: bool = False
+    privacy_level: int = 0
+    
+    # Storage settings
+    storage_backend: StorageBackend = "memory"
+    storage_path: str | None = None
+    
+    # Performance and capacity settings
+    max_records: int = 1000
+    sampling_rate: float = 1.0
+    
+    # Collection behavior
+    include_correct: bool = False
+    auto_flush: bool = False
+    
+    def __post_init__(self) -> None:
+        """Validate configuration values."""
+        if not 0 <= self.privacy_level <= 3:
+            raise ValueError(f"privacy_level must be 0-3, got {self.privacy_level}")
+        
+        if not 0.0 <= self.sampling_rate <= 1.0:
+            raise ValueError(f"sampling_rate must be 0.0-1.0, got {self.sampling_rate}")
+        
+        if self.max_records < 1:
+            raise ValueError(f"max_records must be >= 1, got {self.max_records}")
+        
+        if self.storage_backend == "file" and self.storage_path is None:
+            raise ValueError("storage_path is required when storage_backend='file'")
+        
+        if self.auto_flush and self.storage_backend != "file":
+            raise ValueError("auto_flush requires storage_backend='file'")

--- a/llm_guard/feedback/storage.py
+++ b/llm_guard/feedback/storage.py
@@ -27,23 +27,23 @@ if TYPE_CHECKING:
 class StorageBackend(ABC):
     """
     Abstract base class for feedback storage backends.
-    
+
     All storage implementations must provide three methods:
     - add: Store a feedback record
     - list: Retrieve all stored records
     - clear: Remove all records and return count
     """
-    
+
     @abstractmethod
     def add(self, record: FeedbackRecord) -> None:
         """Add a feedback record to storage."""
         pass
-    
+
     @abstractmethod
     def list(self) -> list[FeedbackRecord]:
         """Retrieve all stored feedback records."""
         pass
-    
+
     @abstractmethod
     def clear(self) -> int:
         """Clear all records and return the count of cleared records."""
@@ -53,35 +53,35 @@ class StorageBackend(ABC):
 class InMemoryStorage(StorageBackend):
     """
     In-memory storage backend with bounded capacity.
-    
+
     Records are stored in a list with a maximum capacity. When the limit
     is exceeded, the oldest records are dropped (FIFO).
-    
+
     This is the default storage backend.
-    
+
     Args:
         max_records: Maximum number of records to keep in memory.
     """
-    
+
     def __init__(self, max_records: int = 1000):
         if max_records < 1:
             raise ValueError(f"max_records must be >= 1, got {max_records}")
-        
+
         self._max_records = max_records
         self._records: list[FeedbackRecord] = []
-    
+
     def add(self, record: FeedbackRecord) -> None:
         """Add a record, dropping oldest if at capacity."""
         self._records.append(record)
-        
+
         # Drop oldest records if over capacity
         if len(self._records) > self._max_records:
-            self._records = self._records[-self._max_records:]
-    
+            self._records = self._records[-self._max_records :]
+
     def list(self) -> list[FeedbackRecord]:
         """Return a copy of all records."""
         return self._records.copy()
-    
+
     def clear(self) -> int:
         """Clear all records and return count."""
         count = len(self._records)
@@ -92,98 +92,98 @@ class InMemoryStorage(StorageBackend):
 class FileStorage(StorageBackend):
     """
     File-based storage backend using JSON serialization.
-    
+
     Records are stored in a JSON file on the local filesystem.
     The file is overwritten on each save operation (simple, safe).
-    
+
     File permissions are set to 0600 (owner read/write only) for security.
-    
+
     Args:
         file_path: Path to the JSON file for storage.
     """
-    
+
     def __init__(self, file_path: str):
         if not file_path:
             raise ValueError("file_path cannot be empty")
-        
+
         self._file_path = Path(file_path)
         self._records: list[FeedbackRecord] = []
-        
+
         # Load existing records if file exists
         if self._file_path.exists():
             self._load()
-    
+
     def add(self, record: FeedbackRecord) -> None:
         """Add a record and save to file."""
         self._records.append(record)
         self._save()
-    
+
     def list(self) -> list[FeedbackRecord]:
         """Return a copy of all records."""
         return self._records.copy()
-    
+
     def clear(self) -> int:
         """Clear all records, delete file, and return count."""
         count = len(self._records)
         self._records.clear()
-        
+
         # Delete the file if it exists
         if self._file_path.exists():
             self._file_path.unlink()
-        
+
         return count
-    
+
     def _load(self) -> None:
         """Load records from JSON file."""
         from .model import FeedbackRecord
-        
+
         try:
-            with open(self._file_path, 'r') as f:
+            with open(self._file_path, "r") as f:
                 data = json.load(f)
-            
+
             # Deserialize records
             self._records = []
             for item in data:
                 # Convert timestamp string back to datetime
-                if 'timestamp' in item and isinstance(item['timestamp'], str):
-                    item['timestamp'] = datetime.fromisoformat(item['timestamp'])
-                
+                if "timestamp" in item and isinstance(item["timestamp"], str):
+                    item["timestamp"] = datetime.fromisoformat(item["timestamp"])
+
                 self._records.append(FeedbackRecord(**item))
-        
-        except (json.JSONDecodeError, KeyError, TypeError) as e:
+
+        except (json.JSONDecodeError, KeyError, TypeError):
             # If file is corrupted, start fresh
             self._records = []
-    
+
     def _save(self) -> None:
         """Save records to JSON file."""
         # Ensure parent directory exists
         self._file_path.parent.mkdir(parents=True, exist_ok=True)
-        
+
         # Serialize records
         data = []
         for record in self._records:
             record_dict = {
-                'record_id': record.record_id,
-                'timestamp': record.timestamp.isoformat(),
-                'scan_type': record.scan_type,
-                'scanner_results': record.scanner_results,
-                'feedback_type': record.feedback_type,
-                'reported_scanners': record.reported_scanners,
-                'user_comment': record.user_comment,
-                'prompt_hash': record.prompt_hash,
-                'output_hash': record.output_hash,
-                'prompt_length': record.prompt_length,
-                'output_length': record.output_length,
-                'scanner_versions': record.scanner_versions,
-                'llm_guard_version': record.llm_guard_version,
-                'prompt_sample': record.prompt_sample,
-                'output_sample': record.output_sample,
+                "record_id": record.record_id,
+                "timestamp": record.timestamp.isoformat(),
+                "scan_type": record.scan_type,
+                "scanner_results": record.scanner_results,
+                "feedback_type": record.feedback_type,
+                "reported_scanners": record.reported_scanners,
+                "user_comment": record.user_comment,
+                "prompt_hash": record.prompt_hash,
+                "output_hash": record.output_hash,
+                "prompt_length": record.prompt_length,
+                "output_length": record.output_length,
+                "scanner_versions": record.scanner_versions,
+                "llm_guard_version": record.llm_guard_version,
+                "prompt_sample": record.prompt_sample,
+                "output_sample": record.output_sample,
             }
             data.append(record_dict)
-        
+
         # Write to file with secure permissions
-        with open(self._file_path, 'w') as f:
+        with open(self._file_path, "w") as f:
             json.dump(data, f, indent=2)
-        
+
         # Set file permissions to 0600 (owner read/write only)
         os.chmod(self._file_path, 0o600)

--- a/llm_guard/feedback/storage.py
+++ b/llm_guard/feedback/storage.py
@@ -1,0 +1,189 @@
+"""
+Storage backends for feedback records.
+
+This module provides a minimal pluggable storage interface with two implementations:
+- InMemoryStorage: Bounded in-memory list (default)
+- FileStorage: JSON file-based storage (local only)
+
+All storage backends implement a simple interface:
+- add(record) -> None
+- list() -> list[FeedbackRecord]
+- clear() -> int
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from abc import ABC, abstractmethod
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .model import FeedbackRecord
+
+
+class StorageBackend(ABC):
+    """
+    Abstract base class for feedback storage backends.
+    
+    All storage implementations must provide three methods:
+    - add: Store a feedback record
+    - list: Retrieve all stored records
+    - clear: Remove all records and return count
+    """
+    
+    @abstractmethod
+    def add(self, record: FeedbackRecord) -> None:
+        """Add a feedback record to storage."""
+        pass
+    
+    @abstractmethod
+    def list(self) -> list[FeedbackRecord]:
+        """Retrieve all stored feedback records."""
+        pass
+    
+    @abstractmethod
+    def clear(self) -> int:
+        """Clear all records and return the count of cleared records."""
+        pass
+
+
+class InMemoryStorage(StorageBackend):
+    """
+    In-memory storage backend with bounded capacity.
+    
+    Records are stored in a list with a maximum capacity. When the limit
+    is exceeded, the oldest records are dropped (FIFO).
+    
+    This is the default storage backend.
+    
+    Args:
+        max_records: Maximum number of records to keep in memory.
+    """
+    
+    def __init__(self, max_records: int = 1000):
+        if max_records < 1:
+            raise ValueError(f"max_records must be >= 1, got {max_records}")
+        
+        self._max_records = max_records
+        self._records: list[FeedbackRecord] = []
+    
+    def add(self, record: FeedbackRecord) -> None:
+        """Add a record, dropping oldest if at capacity."""
+        self._records.append(record)
+        
+        # Drop oldest records if over capacity
+        if len(self._records) > self._max_records:
+            self._records = self._records[-self._max_records:]
+    
+    def list(self) -> list[FeedbackRecord]:
+        """Return a copy of all records."""
+        return self._records.copy()
+    
+    def clear(self) -> int:
+        """Clear all records and return count."""
+        count = len(self._records)
+        self._records.clear()
+        return count
+
+
+class FileStorage(StorageBackend):
+    """
+    File-based storage backend using JSON serialization.
+    
+    Records are stored in a JSON file on the local filesystem.
+    The file is overwritten on each save operation (simple, safe).
+    
+    File permissions are set to 0600 (owner read/write only) for security.
+    
+    Args:
+        file_path: Path to the JSON file for storage.
+    """
+    
+    def __init__(self, file_path: str):
+        if not file_path:
+            raise ValueError("file_path cannot be empty")
+        
+        self._file_path = Path(file_path)
+        self._records: list[FeedbackRecord] = []
+        
+        # Load existing records if file exists
+        if self._file_path.exists():
+            self._load()
+    
+    def add(self, record: FeedbackRecord) -> None:
+        """Add a record and save to file."""
+        self._records.append(record)
+        self._save()
+    
+    def list(self) -> list[FeedbackRecord]:
+        """Return a copy of all records."""
+        return self._records.copy()
+    
+    def clear(self) -> int:
+        """Clear all records, delete file, and return count."""
+        count = len(self._records)
+        self._records.clear()
+        
+        # Delete the file if it exists
+        if self._file_path.exists():
+            self._file_path.unlink()
+        
+        return count
+    
+    def _load(self) -> None:
+        """Load records from JSON file."""
+        from .model import FeedbackRecord
+        
+        try:
+            with open(self._file_path, 'r') as f:
+                data = json.load(f)
+            
+            # Deserialize records
+            self._records = []
+            for item in data:
+                # Convert timestamp string back to datetime
+                if 'timestamp' in item and isinstance(item['timestamp'], str):
+                    item['timestamp'] = datetime.fromisoformat(item['timestamp'])
+                
+                self._records.append(FeedbackRecord(**item))
+        
+        except (json.JSONDecodeError, KeyError, TypeError) as e:
+            # If file is corrupted, start fresh
+            self._records = []
+    
+    def _save(self) -> None:
+        """Save records to JSON file."""
+        # Ensure parent directory exists
+        self._file_path.parent.mkdir(parents=True, exist_ok=True)
+        
+        # Serialize records
+        data = []
+        for record in self._records:
+            record_dict = {
+                'record_id': record.record_id,
+                'timestamp': record.timestamp.isoformat(),
+                'scan_type': record.scan_type,
+                'scanner_results': record.scanner_results,
+                'feedback_type': record.feedback_type,
+                'reported_scanners': record.reported_scanners,
+                'user_comment': record.user_comment,
+                'prompt_hash': record.prompt_hash,
+                'output_hash': record.output_hash,
+                'prompt_length': record.prompt_length,
+                'output_length': record.output_length,
+                'scanner_versions': record.scanner_versions,
+                'llm_guard_version': record.llm_guard_version,
+                'prompt_sample': record.prompt_sample,
+                'output_sample': record.output_sample,
+            }
+            data.append(record_dict)
+        
+        # Write to file with secure permissions
+        with open(self._file_path, 'w') as f:
+            json.dump(data, f, indent=2)
+        
+        # Set file permissions to 0600 (owner read/write only)
+        os.chmod(self._file_path, 0o600)

--- a/llm_guard/feedback/wrapper.py
+++ b/llm_guard/feedback/wrapper.py
@@ -12,52 +12,52 @@ These wrappers are:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Sequence
 
 from llm_guard import scan_output, scan_prompt
 
 if TYPE_CHECKING:
     from llm_guard.input_scanners.base import Scanner as InputScanner
     from llm_guard.output_scanners.base import Scanner as OutputScanner
-    
+
     from .collector import FeedbackCollector
 
 
 def scan_prompt_with_feedback(
-    scanners: list[InputScanner],
+    scanners: Sequence[InputScanner],
     prompt: str,
     collector: FeedbackCollector | None = None,
-    **kwargs
+    **kwargs,
 ) -> tuple[str, dict[str, bool], dict[str, float]]:
     """
     Wrapper around scan_prompt() with optional feedback collection.
-    
+
     This function calls the standard scan_prompt() and optionally records
     the scan result to a FeedbackCollector for feedback tracking.
-    
+
     The return value is EXACTLY the same as scan_prompt().
-    
+
     Args:
         scanners: List of input scanners to apply.
         prompt: The input prompt to scan.
         collector: Optional FeedbackCollector instance. If None or disabled,
                   no feedback is recorded (zero overhead).
         **kwargs: Additional arguments passed to scan_prompt() (e.g., fail_fast).
-    
+
     Returns:
         Tuple of (sanitized_prompt, results_valid, results_score)
         - sanitized_prompt: The sanitized prompt after all scanners
         - results_valid: Dict mapping scanner names to validity (bool)
         - results_score: Dict mapping scanner names to risk scores (float)
-    
+
     Example:
         >>> from llm_guard.input_scanners import Toxicity
         >>> from llm_guard.feedback import FeedbackCollector, FeedbackCollectorConfig
-        >>> 
+        >>>
         >>> config = FeedbackCollectorConfig(enabled=True)
         >>> collector = FeedbackCollector(config)
         >>> scanners = [Toxicity()]
-        >>> 
+        >>>
         >>> sanitized, valid, scores = scan_prompt_with_feedback(
         ...     scanners,
         ...     "Hello world",
@@ -65,10 +65,8 @@ def scan_prompt_with_feedback(
         ... )
     """
     # Call the core scan_prompt function
-    sanitized_prompt, results_valid, results_score = scan_prompt(
-        scanners, prompt, **kwargs
-    )
-    
+    sanitized_prompt, results_valid, results_score = scan_prompt(list(scanners), prompt, **kwargs)
+
     # Record to collector if provided and enabled
     if collector is not None:
         # Build scanner_results in the format expected by collector
@@ -78,7 +76,7 @@ def scan_prompt_with_feedback(
                 "valid": results_valid[scanner_name],
                 "score": results_score[scanner_name],
             }
-        
+
         # Record the scan (collector handles enabled check internally)
         collector.record_scan(
             scan_type="prompt",
@@ -86,26 +84,26 @@ def scan_prompt_with_feedback(
             prompt=prompt,
             output=None,
         )
-    
+
     # Return EXACTLY the same values as scan_prompt
     return sanitized_prompt, results_valid, results_score
 
 
 def scan_output_with_feedback(
-    scanners: list[OutputScanner],
+    scanners: Sequence[OutputScanner],
     prompt: str,
     output: str,
     collector: FeedbackCollector | None = None,
-    **kwargs
+    **kwargs,
 ) -> tuple[str, dict[str, bool], dict[str, float]]:
     """
     Wrapper around scan_output() with optional feedback collection.
-    
+
     This function calls the standard scan_output() and optionally records
     the scan result to a FeedbackCollector for feedback tracking.
-    
+
     The return value is EXACTLY the same as scan_output().
-    
+
     Args:
         scanners: List of output scanners to apply.
         prompt: The original input prompt.
@@ -113,21 +111,21 @@ def scan_output_with_feedback(
         collector: Optional FeedbackCollector instance. If None or disabled,
                   no feedback is recorded (zero overhead).
         **kwargs: Additional arguments passed to scan_output() (e.g., fail_fast).
-    
+
     Returns:
         Tuple of (sanitized_output, results_valid, results_score)
         - sanitized_output: The sanitized output after all scanners
         - results_valid: Dict mapping scanner names to validity (bool)
         - results_score: Dict mapping scanner names to risk scores (float)
-    
+
     Example:
         >>> from llm_guard.output_scanners import Toxicity
         >>> from llm_guard.feedback import FeedbackCollector, FeedbackCollectorConfig
-        >>> 
+        >>>
         >>> config = FeedbackCollectorConfig(enabled=True)
         >>> collector = FeedbackCollector(config)
         >>> scanners = [Toxicity()]
-        >>> 
+        >>>
         >>> sanitized, valid, scores = scan_output_with_feedback(
         ...     scanners,
         ...     "What is AI?",
@@ -137,9 +135,9 @@ def scan_output_with_feedback(
     """
     # Call the core scan_output function
     sanitized_output, results_valid, results_score = scan_output(
-        scanners, prompt, output, **kwargs
+        list(scanners), prompt, output, **kwargs
     )
-    
+
     # Record to collector if provided and enabled
     if collector is not None:
         # Build scanner_results in the format expected by collector
@@ -149,7 +147,7 @@ def scan_output_with_feedback(
                 "valid": results_valid[scanner_name],
                 "score": results_score[scanner_name],
             }
-        
+
         # Record the scan (collector handles enabled check internally)
         collector.record_scan(
             scan_type="output",
@@ -157,6 +155,6 @@ def scan_output_with_feedback(
             prompt=prompt,
             output=output,
         )
-    
+
     # Return EXACTLY the same values as scan_output
     return sanitized_output, results_valid, results_score

--- a/llm_guard/feedback/wrapper.py
+++ b/llm_guard/feedback/wrapper.py
@@ -1,0 +1,162 @@
+"""
+Wrapper functions for integrating feedback collection with llm-guard scanning.
+
+This module provides thin wrapper functions around scan_prompt() and scan_output()
+that optionally record scan results to a FeedbackCollector.
+
+These wrappers are:
+- Drop-in replacements (same signatures + optional collector parameter)
+- Side-effect-free when collector is None or disabled
+- Non-invasive (no modification to core scanning behavior)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from llm_guard import scan_output, scan_prompt
+
+if TYPE_CHECKING:
+    from llm_guard.input_scanners.base import Scanner as InputScanner
+    from llm_guard.output_scanners.base import Scanner as OutputScanner
+    
+    from .collector import FeedbackCollector
+
+
+def scan_prompt_with_feedback(
+    scanners: list[InputScanner],
+    prompt: str,
+    collector: FeedbackCollector | None = None,
+    **kwargs
+) -> tuple[str, dict[str, bool], dict[str, float]]:
+    """
+    Wrapper around scan_prompt() with optional feedback collection.
+    
+    This function calls the standard scan_prompt() and optionally records
+    the scan result to a FeedbackCollector for feedback tracking.
+    
+    The return value is EXACTLY the same as scan_prompt().
+    
+    Args:
+        scanners: List of input scanners to apply.
+        prompt: The input prompt to scan.
+        collector: Optional FeedbackCollector instance. If None or disabled,
+                  no feedback is recorded (zero overhead).
+        **kwargs: Additional arguments passed to scan_prompt() (e.g., fail_fast).
+    
+    Returns:
+        Tuple of (sanitized_prompt, results_valid, results_score)
+        - sanitized_prompt: The sanitized prompt after all scanners
+        - results_valid: Dict mapping scanner names to validity (bool)
+        - results_score: Dict mapping scanner names to risk scores (float)
+    
+    Example:
+        >>> from llm_guard.input_scanners import Toxicity
+        >>> from llm_guard.feedback import FeedbackCollector, FeedbackCollectorConfig
+        >>> 
+        >>> config = FeedbackCollectorConfig(enabled=True)
+        >>> collector = FeedbackCollector(config)
+        >>> scanners = [Toxicity()]
+        >>> 
+        >>> sanitized, valid, scores = scan_prompt_with_feedback(
+        ...     scanners,
+        ...     "Hello world",
+        ...     collector=collector
+        ... )
+    """
+    # Call the core scan_prompt function
+    sanitized_prompt, results_valid, results_score = scan_prompt(
+        scanners, prompt, **kwargs
+    )
+    
+    # Record to collector if provided and enabled
+    if collector is not None:
+        # Build scanner_results in the format expected by collector
+        scanner_results = {}
+        for scanner_name in results_valid.keys():
+            scanner_results[scanner_name] = {
+                "valid": results_valid[scanner_name],
+                "score": results_score[scanner_name],
+            }
+        
+        # Record the scan (collector handles enabled check internally)
+        collector.record_scan(
+            scan_type="prompt",
+            scanner_results=scanner_results,
+            prompt=prompt,
+            output=None,
+        )
+    
+    # Return EXACTLY the same values as scan_prompt
+    return sanitized_prompt, results_valid, results_score
+
+
+def scan_output_with_feedback(
+    scanners: list[OutputScanner],
+    prompt: str,
+    output: str,
+    collector: FeedbackCollector | None = None,
+    **kwargs
+) -> tuple[str, dict[str, bool], dict[str, float]]:
+    """
+    Wrapper around scan_output() with optional feedback collection.
+    
+    This function calls the standard scan_output() and optionally records
+    the scan result to a FeedbackCollector for feedback tracking.
+    
+    The return value is EXACTLY the same as scan_output().
+    
+    Args:
+        scanners: List of output scanners to apply.
+        prompt: The original input prompt.
+        output: The output to scan.
+        collector: Optional FeedbackCollector instance. If None or disabled,
+                  no feedback is recorded (zero overhead).
+        **kwargs: Additional arguments passed to scan_output() (e.g., fail_fast).
+    
+    Returns:
+        Tuple of (sanitized_output, results_valid, results_score)
+        - sanitized_output: The sanitized output after all scanners
+        - results_valid: Dict mapping scanner names to validity (bool)
+        - results_score: Dict mapping scanner names to risk scores (float)
+    
+    Example:
+        >>> from llm_guard.output_scanners import Toxicity
+        >>> from llm_guard.feedback import FeedbackCollector, FeedbackCollectorConfig
+        >>> 
+        >>> config = FeedbackCollectorConfig(enabled=True)
+        >>> collector = FeedbackCollector(config)
+        >>> scanners = [Toxicity()]
+        >>> 
+        >>> sanitized, valid, scores = scan_output_with_feedback(
+        ...     scanners,
+        ...     "What is AI?",
+        ...     "AI is artificial intelligence",
+        ...     collector=collector
+        ... )
+    """
+    # Call the core scan_output function
+    sanitized_output, results_valid, results_score = scan_output(
+        scanners, prompt, output, **kwargs
+    )
+    
+    # Record to collector if provided and enabled
+    if collector is not None:
+        # Build scanner_results in the format expected by collector
+        scanner_results = {}
+        for scanner_name in results_valid.keys():
+            scanner_results[scanner_name] = {
+                "valid": results_valid[scanner_name],
+                "score": results_score[scanner_name],
+            }
+        
+        # Record the scan (collector handles enabled check internally)
+        collector.record_scan(
+            scan_type="output",
+            scanner_results=scanner_results,
+            prompt=prompt,
+            output=output,
+        )
+    
+    # Return EXACTLY the same values as scan_output
+    return sanitized_output, results_valid, results_score

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -10,5 +10,8 @@
     "benchmarks",
     "examples",
     "llm_guard_api"
-  ]
+  ],
+  "reportMissingImports": "none",
+  "reportArgumentType": "warning",
+  "reportAbstractUsage": "warning"
 }

--- a/tests/feedback/__init__.py
+++ b/tests/feedback/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for llm_guard.feedback module."""

--- a/tests/feedback/test_collector.py
+++ b/tests/feedback/test_collector.py
@@ -16,36 +16,34 @@ from llm_guard.feedback import FeedbackCollector, FeedbackCollectorConfig
 
 class TestFeedbackCollectorDisabled:
     """Tests for FeedbackCollector when disabled."""
-    
+
     def test_default_config_is_disabled(self):
         """Test that default configuration is disabled."""
         collector = FeedbackCollector()
-        
+
         # All methods should be no-ops
         record_id = collector.record_scan("prompt", {})
         assert record_id is None
-        
+
         assert collector.report_feedback("test", "false_positive", []) is False
         assert collector.get_records() == []
         assert collector.clear_records() == 0
-        
+
         stats = collector.get_stats()
         assert stats["enabled"] is False
         assert stats["total_records"] == 0
-    
+
     def test_explicit_disabled_config(self):
         """Test collector with explicitly disabled config."""
         config = FeedbackCollectorConfig(enabled=False)
         collector = FeedbackCollector(config)
-        
+
         # Should be no-op
         record_id = collector.record_scan(
-            "prompt",
-            {"Toxicity": {"valid": False, "score": 0.9}},
-            prompt="test"
+            "prompt", {"Toxicity": {"valid": False, "score": 0.9}}, prompt="test"
         )
         assert record_id is None
-    
+
     def test_disabled_has_no_storage(self):
         """Test that disabled collector doesn't create storage."""
         collector = FeedbackCollector()
@@ -54,211 +52,200 @@ class TestFeedbackCollectorDisabled:
 
 class TestFeedbackCollectorEnabled:
     """Tests for FeedbackCollector when enabled."""
-    
+
     def test_record_scan_basic(self):
         """Test basic scan recording."""
         config = FeedbackCollectorConfig(enabled=True)
         collector = FeedbackCollector(config)
-        
+
         record_id = collector.record_scan(
             scan_type="prompt",
             scanner_results={"Toxicity": {"valid": False, "score": 0.9}},
-            prompt="This is toxic"
+            prompt="This is toxic",
         )
-        
+
         assert record_id is not None
         assert len(collector.get_records()) == 1
-    
+
     def test_record_scan_with_output(self):
         """Test recording output scan."""
         config = FeedbackCollectorConfig(enabled=True)
         collector = FeedbackCollector(config)
-        
+
         record_id = collector.record_scan(
             scan_type="output",
             scanner_results={"Bias": {"valid": False, "score": 0.8}},  # Changed to False
             prompt="What is AI?",
-            output="AI is artificial intelligence"
+            output="AI is artificial intelligence",
         )
-        
+
         assert record_id is not None
         records = collector.get_records()
         assert len(records) == 1
         assert records[0].scan_type == "output"
         assert records[0].output_hash is not None
-    
+
     def test_privacy_level_0_no_samples(self):
         """Test that privacy level 0 stores no text samples."""
         config = FeedbackCollectorConfig(enabled=True, privacy_level=0)
         collector = FeedbackCollector(config)
-        
+
         collector.record_scan(
-            "prompt",
-            {"Toxicity": {"valid": False, "score": 0.9}},
-            prompt="This is a test prompt"
+            "prompt", {"Toxicity": {"valid": False, "score": 0.9}}, prompt="This is a test prompt"
         )
-        
+
         records = collector.get_records()
         assert len(records) == 1
         assert records[0].prompt_sample is None
         assert records[0].prompt_hash is not None  # Hash should exist
         assert records[0].prompt_length > 0  # Length should exist
-    
+
     def test_privacy_level_1_with_samples(self):
         """Test that privacy level 1 includes text samples."""
         config = FeedbackCollectorConfig(enabled=True, privacy_level=1)
         collector = FeedbackCollector(config)
-        
+
         long_prompt = "A" * 100
         collector.record_scan(
-            "prompt",
-            {"Toxicity": {"valid": False, "score": 0.9}},
-            prompt=long_prompt
+            "prompt", {"Toxicity": {"valid": False, "score": 0.9}}, prompt=long_prompt
         )
-        
+
         records = collector.get_records()
         assert len(records) == 1
         assert records[0].prompt_sample is not None
         assert len(records[0].prompt_sample) == 50  # First 50 chars
-    
+
     def test_include_correct_false(self):
         """Test that correct scans are not recorded by default."""
         config = FeedbackCollectorConfig(enabled=True, include_correct=False)
         collector = FeedbackCollector(config)
-        
+
         # All scanners valid
         record_id = collector.record_scan(
-            "prompt",
-            {"Toxicity": {"valid": True, "score": 0.1}},
-            prompt="Hello"
+            "prompt", {"Toxicity": {"valid": True, "score": 0.1}}, prompt="Hello"
         )
-        
+
         assert record_id is None
         assert len(collector.get_records()) == 0
-    
+
     def test_include_correct_true(self):
         """Test that correct scans are recorded when configured."""
         config = FeedbackCollectorConfig(enabled=True, include_correct=True)
         collector = FeedbackCollector(config)
-        
+
         # All scanners valid
         record_id = collector.record_scan(
-            "prompt",
-            {"Toxicity": {"valid": True, "score": 0.1}},
-            prompt="Hello"
+            "prompt", {"Toxicity": {"valid": True, "score": 0.1}}, prompt="Hello"
         )
-        
+
         assert record_id is not None
         assert len(collector.get_records()) == 1
-    
+
     def test_sampling_rate(self):
         """Test that sampling rate is respected."""
         config = FeedbackCollectorConfig(enabled=True, sampling_rate=0.0)
         collector = FeedbackCollector(config)
-        
+
         # With 0% sampling, nothing should be recorded
         for _ in range(10):
             record_id = collector.record_scan(
-                "prompt",
-                {"Toxicity": {"valid": False, "score": 0.9}},
-                prompt="test"
+                "prompt", {"Toxicity": {"valid": False, "score": 0.9}}, prompt="test"
             )
             assert record_id is None
-        
+
         assert len(collector.get_records()) == 0
-    
+
     def test_report_feedback(self):
         """Test adding feedback to a record."""
         config = FeedbackCollectorConfig(enabled=True)
         collector = FeedbackCollector(config)
-        
+
         record_id = collector.record_scan(
-            "prompt",
-            {"Toxicity": {"valid": False, "score": 0.9}},
-            prompt="test"
+            "prompt", {"Toxicity": {"valid": False, "score": 0.9}}, prompt="test"
         )
-        
+
+        assert record_id is not None
+
         # Add feedback
         success = collector.report_feedback(
-            record_id,
-            "false_positive",
-            ["Toxicity"],
-            "This is not toxic"
+            record_id, "false_positive", ["Toxicity"], "This is not toxic"
         )
-        
+
         assert success is True
-        
+
         # Verify feedback was added
         records = collector.get_records()
         assert len(records) == 1
         assert records[0].feedback_type == "false_positive"
         assert records[0].reported_scanners == ["Toxicity"]
         assert records[0].user_comment == "This is not toxic"
-    
+
     def test_report_feedback_nonexistent_record(self):
         """Test reporting feedback for nonexistent record."""
         config = FeedbackCollectorConfig(enabled=True)
         collector = FeedbackCollector(config)
-        
-        success = collector.report_feedback(
-            "nonexistent-id",
-            "false_positive",
-            ["Toxicity"]
-        )
-        
+
+        success = collector.report_feedback("nonexistent-id", "false_positive", ["Toxicity"])
+
         assert success is False
-    
+
     def test_get_records_with_filter(self):
         """Test filtering records."""
         config = FeedbackCollectorConfig(enabled=True)
         collector = FeedbackCollector(config)
-        
+
         # Add multiple records
         id1 = collector.record_scan("prompt", {"Toxicity": {"valid": False, "score": 0.9}})
         id2 = collector.record_scan("output", {"Bias": {"valid": False, "score": 0.8}})
-        
+
+        assert id1 is not None
+        assert id2 is not None
+
         collector.report_feedback(id1, "false_positive", ["Toxicity"])
-        
+
         # Filter by feedback_type
         filtered = collector.get_records(filter_by={"feedback_type": "false_positive"})
         assert len(filtered) == 1
         assert filtered[0].record_id == id1
-        
+
         # Filter by scan_type
         filtered = collector.get_records(filter_by={"scan_type": "output"})
         assert len(filtered) == 1
         assert filtered[0].record_id == id2
-    
+
     def test_clear_records(self):
         """Test clearing all records."""
         config = FeedbackCollectorConfig(enabled=True)
         collector = FeedbackCollector(config)
-        
+
         # Add some records
         for i in range(5):
             collector.record_scan("prompt", {"Toxicity": {"valid": False, "score": 0.9}})
-        
+
         assert len(collector.get_records()) == 5
-        
+
         count = collector.clear_records()
         assert count == 5
         assert len(collector.get_records()) == 0
-    
+
     def test_get_stats(self):
         """Test getting statistics."""
         config = FeedbackCollectorConfig(enabled=True, privacy_level=1)
         collector = FeedbackCollector(config)
-        
+
         # Add records with different feedback types
         id1 = collector.record_scan("prompt", {"Toxicity": {"valid": False, "score": 0.9}})
         id2 = collector.record_scan("prompt", {"Toxicity": {"valid": False, "score": 0.9}})
-        id3 = collector.record_scan("prompt", {"Toxicity": {"valid": False, "score": 0.9}})
-        
+        _id3 = collector.record_scan("prompt", {"Toxicity": {"valid": False, "score": 0.9}})
+
+        assert id1 is not None
+        assert id2 is not None
+
         collector.report_feedback(id1, "false_positive", ["Toxicity"])
         collector.report_feedback(id2, "false_negative", ["Toxicity"])
-        
+
         stats = collector.get_stats()
-        
+
         assert stats["enabled"] is True
         assert stats["total_records"] == 3
         assert stats["privacy_level"] == 1
@@ -270,137 +257,124 @@ class TestFeedbackCollectorEnabled:
 
 class TestFeedbackCollectorWithFileStorage:
     """Tests for FeedbackCollector with file storage."""
-    
+
     def test_file_storage_backend(self):
         """Test using file storage backend."""
         with tempfile.TemporaryDirectory() as tmpdir:
             file_path = Path(tmpdir) / "feedback.json"
-            
+
             config = FeedbackCollectorConfig(
-                enabled=True,
-                storage_backend="file",
-                storage_path=str(file_path)
+                enabled=True, storage_backend="file", storage_path=str(file_path)
             )
             collector = FeedbackCollector(config)
-            
+
             collector.record_scan(
-                "prompt",
-                {"Toxicity": {"valid": False, "score": 0.9}},
-                prompt="test"
+                "prompt", {"Toxicity": {"valid": False, "score": 0.9}}, prompt="test"
             )
-            
+
             assert file_path.exists()
             assert len(collector.get_records()) == 1
-    
+
     def test_file_storage_persistence(self):
         """Test that file storage persists across collector instances."""
         with tempfile.TemporaryDirectory() as tmpdir:
             file_path = Path(tmpdir) / "feedback.json"
-            
+
             # Create first collector and add record
             config1 = FeedbackCollectorConfig(
-                enabled=True,
-                storage_backend="file",
-                storage_path=str(file_path)
+                enabled=True, storage_backend="file", storage_path=str(file_path)
             )
             collector1 = FeedbackCollector(config1)
             collector1.record_scan("prompt", {"Toxicity": {"valid": False, "score": 0.9}})
-            
+
             # Create second collector (should load from file)
             config2 = FeedbackCollectorConfig(
-                enabled=True,
-                storage_backend="file",
-                storage_path=str(file_path)
+                enabled=True, storage_backend="file", storage_path=str(file_path)
             )
             collector2 = FeedbackCollector(config2)
-            
+
             assert len(collector2.get_records()) == 1
 
 
 class TestFeedbackCollectorWithMemoryStorage:
     """Tests for FeedbackCollector with memory storage."""
-    
+
     def test_memory_storage_respects_max_records(self):
         """Test that memory storage respects max_records limit."""
-        config = FeedbackCollectorConfig(
-            enabled=True,
-            storage_backend="memory",
-            max_records=3
-        )
+        config = FeedbackCollectorConfig(enabled=True, storage_backend="memory", max_records=3)
         collector = FeedbackCollector(config)
-        
+
         # Add 5 records
         for i in range(5):
             collector.record_scan("prompt", {"Toxicity": {"valid": False, "score": 0.9}})
-        
+
         # Should only keep last 3
         assert len(collector.get_records()) == 3
 
 
 class TestFeedbackCollectorValidation:
     """Tests for FeedbackCollector validation."""
-    
+
     def test_unsupported_storage_backend(self):
         """Test that unsupported storage backend raises error."""
         config = FeedbackCollectorConfig(
             enabled=True,
-            storage_backend="custom"  # Not supported in Phase 2
+            storage_backend="custom",  # Not supported in Phase 2
         )
-        
+
         with pytest.raises(ValueError, match="Unsupported storage backend"):
             FeedbackCollector(config)
-    
+
     def test_file_backend_without_path(self):
         """Test that file backend without path raises error."""
         # This should be caught by FeedbackCollectorConfig validation
         with pytest.raises(ValueError, match="storage_path is required"):
             FeedbackCollectorConfig(
                 enabled=True,
-                storage_backend="file"
+                storage_backend="file",
                 # storage_path not provided
             )
 
 
 class TestPhase1And2Integration:
     """Tests verifying Phase 1 and Phase 2 work together."""
-    
+
     def test_phase1_models_still_work(self):
         """Test that Phase 1 data models still work correctly."""
-        from llm_guard.feedback import FeedbackRecord, FeedbackCollectorConfig
-        
+        from llm_guard.feedback import FeedbackCollectorConfig, FeedbackRecord
+
         # Test FeedbackRecord
         record = FeedbackRecord(
-            record_id="test",
-            timestamp=datetime.now(),
-            scan_type="prompt",
-            scanner_results={}
+            record_id="test", timestamp=datetime.now(), scan_type="prompt", scanner_results={}
         )
         assert record.record_id == "test"
-        
+
         # Test FeedbackCollectorConfig
         config = FeedbackCollectorConfig(enabled=True, privacy_level=2)
         assert config.enabled is True
         assert config.privacy_level == 2
-    
+
     def test_collector_uses_phase1_models(self):
         """Test that collector correctly uses Phase 1 models."""
         config = FeedbackCollectorConfig(enabled=True)
         collector = FeedbackCollector(config)
-        
+
         collector.record_scan("prompt", {"Toxicity": {"valid": False, "score": 0.9}})
-        
+
         records = collector.get_records()
         assert len(records) == 1
-        
+
         # Verify it's a FeedbackRecord instance
         from llm_guard.feedback import FeedbackRecord
+
         assert isinstance(records[0], FeedbackRecord)
-    
+
     def test_no_core_llm_guard_impact(self):
         """Test that feedback module doesn't impact core llm_guard."""
         # This should still work
         try:
-            import llm_guard
+            import llm_guard  # noqa: F401
+
             # If this doesn't raise, core is unaffected
             assert True
         except ImportError:

--- a/tests/feedback/test_collector.py
+++ b/tests/feedback/test_collector.py
@@ -1,0 +1,408 @@
+"""
+Tests for FeedbackCollector.
+
+These tests verify the collector logic, privacy controls, and integration
+with storage backends.
+"""
+
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from llm_guard.feedback import FeedbackCollector, FeedbackCollectorConfig
+
+
+class TestFeedbackCollectorDisabled:
+    """Tests for FeedbackCollector when disabled."""
+    
+    def test_default_config_is_disabled(self):
+        """Test that default configuration is disabled."""
+        collector = FeedbackCollector()
+        
+        # All methods should be no-ops
+        record_id = collector.record_scan("prompt", {})
+        assert record_id is None
+        
+        assert collector.report_feedback("test", "false_positive", []) is False
+        assert collector.get_records() == []
+        assert collector.clear_records() == 0
+        
+        stats = collector.get_stats()
+        assert stats["enabled"] is False
+        assert stats["total_records"] == 0
+    
+    def test_explicit_disabled_config(self):
+        """Test collector with explicitly disabled config."""
+        config = FeedbackCollectorConfig(enabled=False)
+        collector = FeedbackCollector(config)
+        
+        # Should be no-op
+        record_id = collector.record_scan(
+            "prompt",
+            {"Toxicity": {"valid": False, "score": 0.9}},
+            prompt="test"
+        )
+        assert record_id is None
+    
+    def test_disabled_has_no_storage(self):
+        """Test that disabled collector doesn't create storage."""
+        collector = FeedbackCollector()
+        assert collector._storage is None
+
+
+class TestFeedbackCollectorEnabled:
+    """Tests for FeedbackCollector when enabled."""
+    
+    def test_record_scan_basic(self):
+        """Test basic scan recording."""
+        config = FeedbackCollectorConfig(enabled=True)
+        collector = FeedbackCollector(config)
+        
+        record_id = collector.record_scan(
+            scan_type="prompt",
+            scanner_results={"Toxicity": {"valid": False, "score": 0.9}},
+            prompt="This is toxic"
+        )
+        
+        assert record_id is not None
+        assert len(collector.get_records()) == 1
+    
+    def test_record_scan_with_output(self):
+        """Test recording output scan."""
+        config = FeedbackCollectorConfig(enabled=True)
+        collector = FeedbackCollector(config)
+        
+        record_id = collector.record_scan(
+            scan_type="output",
+            scanner_results={"Bias": {"valid": False, "score": 0.8}},  # Changed to False
+            prompt="What is AI?",
+            output="AI is artificial intelligence"
+        )
+        
+        assert record_id is not None
+        records = collector.get_records()
+        assert len(records) == 1
+        assert records[0].scan_type == "output"
+        assert records[0].output_hash is not None
+    
+    def test_privacy_level_0_no_samples(self):
+        """Test that privacy level 0 stores no text samples."""
+        config = FeedbackCollectorConfig(enabled=True, privacy_level=0)
+        collector = FeedbackCollector(config)
+        
+        collector.record_scan(
+            "prompt",
+            {"Toxicity": {"valid": False, "score": 0.9}},
+            prompt="This is a test prompt"
+        )
+        
+        records = collector.get_records()
+        assert len(records) == 1
+        assert records[0].prompt_sample is None
+        assert records[0].prompt_hash is not None  # Hash should exist
+        assert records[0].prompt_length > 0  # Length should exist
+    
+    def test_privacy_level_1_with_samples(self):
+        """Test that privacy level 1 includes text samples."""
+        config = FeedbackCollectorConfig(enabled=True, privacy_level=1)
+        collector = FeedbackCollector(config)
+        
+        long_prompt = "A" * 100
+        collector.record_scan(
+            "prompt",
+            {"Toxicity": {"valid": False, "score": 0.9}},
+            prompt=long_prompt
+        )
+        
+        records = collector.get_records()
+        assert len(records) == 1
+        assert records[0].prompt_sample is not None
+        assert len(records[0].prompt_sample) == 50  # First 50 chars
+    
+    def test_include_correct_false(self):
+        """Test that correct scans are not recorded by default."""
+        config = FeedbackCollectorConfig(enabled=True, include_correct=False)
+        collector = FeedbackCollector(config)
+        
+        # All scanners valid
+        record_id = collector.record_scan(
+            "prompt",
+            {"Toxicity": {"valid": True, "score": 0.1}},
+            prompt="Hello"
+        )
+        
+        assert record_id is None
+        assert len(collector.get_records()) == 0
+    
+    def test_include_correct_true(self):
+        """Test that correct scans are recorded when configured."""
+        config = FeedbackCollectorConfig(enabled=True, include_correct=True)
+        collector = FeedbackCollector(config)
+        
+        # All scanners valid
+        record_id = collector.record_scan(
+            "prompt",
+            {"Toxicity": {"valid": True, "score": 0.1}},
+            prompt="Hello"
+        )
+        
+        assert record_id is not None
+        assert len(collector.get_records()) == 1
+    
+    def test_sampling_rate(self):
+        """Test that sampling rate is respected."""
+        config = FeedbackCollectorConfig(enabled=True, sampling_rate=0.0)
+        collector = FeedbackCollector(config)
+        
+        # With 0% sampling, nothing should be recorded
+        for _ in range(10):
+            record_id = collector.record_scan(
+                "prompt",
+                {"Toxicity": {"valid": False, "score": 0.9}},
+                prompt="test"
+            )
+            assert record_id is None
+        
+        assert len(collector.get_records()) == 0
+    
+    def test_report_feedback(self):
+        """Test adding feedback to a record."""
+        config = FeedbackCollectorConfig(enabled=True)
+        collector = FeedbackCollector(config)
+        
+        record_id = collector.record_scan(
+            "prompt",
+            {"Toxicity": {"valid": False, "score": 0.9}},
+            prompt="test"
+        )
+        
+        # Add feedback
+        success = collector.report_feedback(
+            record_id,
+            "false_positive",
+            ["Toxicity"],
+            "This is not toxic"
+        )
+        
+        assert success is True
+        
+        # Verify feedback was added
+        records = collector.get_records()
+        assert len(records) == 1
+        assert records[0].feedback_type == "false_positive"
+        assert records[0].reported_scanners == ["Toxicity"]
+        assert records[0].user_comment == "This is not toxic"
+    
+    def test_report_feedback_nonexistent_record(self):
+        """Test reporting feedback for nonexistent record."""
+        config = FeedbackCollectorConfig(enabled=True)
+        collector = FeedbackCollector(config)
+        
+        success = collector.report_feedback(
+            "nonexistent-id",
+            "false_positive",
+            ["Toxicity"]
+        )
+        
+        assert success is False
+    
+    def test_get_records_with_filter(self):
+        """Test filtering records."""
+        config = FeedbackCollectorConfig(enabled=True)
+        collector = FeedbackCollector(config)
+        
+        # Add multiple records
+        id1 = collector.record_scan("prompt", {"Toxicity": {"valid": False, "score": 0.9}})
+        id2 = collector.record_scan("output", {"Bias": {"valid": False, "score": 0.8}})
+        
+        collector.report_feedback(id1, "false_positive", ["Toxicity"])
+        
+        # Filter by feedback_type
+        filtered = collector.get_records(filter_by={"feedback_type": "false_positive"})
+        assert len(filtered) == 1
+        assert filtered[0].record_id == id1
+        
+        # Filter by scan_type
+        filtered = collector.get_records(filter_by={"scan_type": "output"})
+        assert len(filtered) == 1
+        assert filtered[0].record_id == id2
+    
+    def test_clear_records(self):
+        """Test clearing all records."""
+        config = FeedbackCollectorConfig(enabled=True)
+        collector = FeedbackCollector(config)
+        
+        # Add some records
+        for i in range(5):
+            collector.record_scan("prompt", {"Toxicity": {"valid": False, "score": 0.9}})
+        
+        assert len(collector.get_records()) == 5
+        
+        count = collector.clear_records()
+        assert count == 5
+        assert len(collector.get_records()) == 0
+    
+    def test_get_stats(self):
+        """Test getting statistics."""
+        config = FeedbackCollectorConfig(enabled=True, privacy_level=1)
+        collector = FeedbackCollector(config)
+        
+        # Add records with different feedback types
+        id1 = collector.record_scan("prompt", {"Toxicity": {"valid": False, "score": 0.9}})
+        id2 = collector.record_scan("prompt", {"Toxicity": {"valid": False, "score": 0.9}})
+        id3 = collector.record_scan("prompt", {"Toxicity": {"valid": False, "score": 0.9}})
+        
+        collector.report_feedback(id1, "false_positive", ["Toxicity"])
+        collector.report_feedback(id2, "false_negative", ["Toxicity"])
+        
+        stats = collector.get_stats()
+        
+        assert stats["enabled"] is True
+        assert stats["total_records"] == 3
+        assert stats["privacy_level"] == 1
+        assert stats["storage_backend"] == "memory"
+        assert stats["feedback_counts"]["false_positive"] == 1
+        assert stats["feedback_counts"]["false_negative"] == 1
+        assert stats["feedback_counts"]["no_feedback"] == 1
+
+
+class TestFeedbackCollectorWithFileStorage:
+    """Tests for FeedbackCollector with file storage."""
+    
+    def test_file_storage_backend(self):
+        """Test using file storage backend."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "feedback.json"
+            
+            config = FeedbackCollectorConfig(
+                enabled=True,
+                storage_backend="file",
+                storage_path=str(file_path)
+            )
+            collector = FeedbackCollector(config)
+            
+            collector.record_scan(
+                "prompt",
+                {"Toxicity": {"valid": False, "score": 0.9}},
+                prompt="test"
+            )
+            
+            assert file_path.exists()
+            assert len(collector.get_records()) == 1
+    
+    def test_file_storage_persistence(self):
+        """Test that file storage persists across collector instances."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "feedback.json"
+            
+            # Create first collector and add record
+            config1 = FeedbackCollectorConfig(
+                enabled=True,
+                storage_backend="file",
+                storage_path=str(file_path)
+            )
+            collector1 = FeedbackCollector(config1)
+            collector1.record_scan("prompt", {"Toxicity": {"valid": False, "score": 0.9}})
+            
+            # Create second collector (should load from file)
+            config2 = FeedbackCollectorConfig(
+                enabled=True,
+                storage_backend="file",
+                storage_path=str(file_path)
+            )
+            collector2 = FeedbackCollector(config2)
+            
+            assert len(collector2.get_records()) == 1
+
+
+class TestFeedbackCollectorWithMemoryStorage:
+    """Tests for FeedbackCollector with memory storage."""
+    
+    def test_memory_storage_respects_max_records(self):
+        """Test that memory storage respects max_records limit."""
+        config = FeedbackCollectorConfig(
+            enabled=True,
+            storage_backend="memory",
+            max_records=3
+        )
+        collector = FeedbackCollector(config)
+        
+        # Add 5 records
+        for i in range(5):
+            collector.record_scan("prompt", {"Toxicity": {"valid": False, "score": 0.9}})
+        
+        # Should only keep last 3
+        assert len(collector.get_records()) == 3
+
+
+class TestFeedbackCollectorValidation:
+    """Tests for FeedbackCollector validation."""
+    
+    def test_unsupported_storage_backend(self):
+        """Test that unsupported storage backend raises error."""
+        config = FeedbackCollectorConfig(
+            enabled=True,
+            storage_backend="custom"  # Not supported in Phase 2
+        )
+        
+        with pytest.raises(ValueError, match="Unsupported storage backend"):
+            FeedbackCollector(config)
+    
+    def test_file_backend_without_path(self):
+        """Test that file backend without path raises error."""
+        # This should be caught by FeedbackCollectorConfig validation
+        with pytest.raises(ValueError, match="storage_path is required"):
+            FeedbackCollectorConfig(
+                enabled=True,
+                storage_backend="file"
+                # storage_path not provided
+            )
+
+
+class TestPhase1And2Integration:
+    """Tests verifying Phase 1 and Phase 2 work together."""
+    
+    def test_phase1_models_still_work(self):
+        """Test that Phase 1 data models still work correctly."""
+        from llm_guard.feedback import FeedbackRecord, FeedbackCollectorConfig
+        
+        # Test FeedbackRecord
+        record = FeedbackRecord(
+            record_id="test",
+            timestamp=datetime.now(),
+            scan_type="prompt",
+            scanner_results={}
+        )
+        assert record.record_id == "test"
+        
+        # Test FeedbackCollectorConfig
+        config = FeedbackCollectorConfig(enabled=True, privacy_level=2)
+        assert config.enabled is True
+        assert config.privacy_level == 2
+    
+    def test_collector_uses_phase1_models(self):
+        """Test that collector correctly uses Phase 1 models."""
+        config = FeedbackCollectorConfig(enabled=True)
+        collector = FeedbackCollector(config)
+        
+        collector.record_scan("prompt", {"Toxicity": {"valid": False, "score": 0.9}})
+        
+        records = collector.get_records()
+        assert len(records) == 1
+        
+        # Verify it's a FeedbackRecord instance
+        from llm_guard.feedback import FeedbackRecord
+        assert isinstance(records[0], FeedbackRecord)
+    
+    def test_no_core_llm_guard_impact(self):
+        """Test that feedback module doesn't impact core llm_guard."""
+        # This should still work
+        try:
+            import llm_guard
+            # If this doesn't raise, core is unaffected
+            assert True
+        except ImportError:
+            # Expected if presidio not installed (from Phase 1)
+            assert True

--- a/tests/feedback/test_model.py
+++ b/tests/feedback/test_model.py
@@ -1,0 +1,234 @@
+"""
+Tests for feedback data models.
+
+These tests verify dataclass instantiation, default values, and validation logic.
+No runtime behavior or integration testing is included in Phase 1.
+"""
+
+from datetime import datetime
+
+import pytest
+
+from llm_guard.feedback.model import FeedbackCollectorConfig, FeedbackRecord
+
+
+class TestFeedbackRecord:
+    """Tests for FeedbackRecord dataclass."""
+    
+    def test_minimal_instantiation(self):
+        """Test creating a FeedbackRecord with only required fields."""
+        record = FeedbackRecord(
+            record_id="test-123",
+            timestamp=datetime.now(),
+            scan_type="prompt",
+            scanner_results={"Toxicity": {"valid": True, "score": 0.1}},
+        )
+        
+        assert record.record_id == "test-123"
+        assert record.scan_type == "prompt"
+        assert record.scanner_results == {"Toxicity": {"valid": True, "score": 0.1}}
+        
+        # Verify defaults
+        assert record.feedback_type is None
+        assert record.reported_scanners == []
+        assert record.user_comment is None
+        assert record.prompt_hash is None
+        assert record.output_hash is None
+        assert record.prompt_length == 0
+        assert record.output_length is None
+        assert record.scanner_versions == {}
+        assert record.llm_guard_version == ""
+        assert record.prompt_sample is None
+        assert record.output_sample is None
+    
+    def test_full_instantiation(self):
+        """Test creating a FeedbackRecord with all fields populated."""
+        now = datetime.now()
+        record = FeedbackRecord(
+            record_id="test-456",
+            timestamp=now,
+            scan_type="output",
+            scanner_results={
+                "Toxicity": {"valid": False, "score": 0.9},
+                "Bias": {"valid": True, "score": 0.2},
+            },
+            feedback_type="false_positive",
+            reported_scanners=["Toxicity"],
+            user_comment="This is not toxic",
+            prompt_hash="abc123",
+            output_hash="def456",
+            prompt_length=50,
+            output_length=100,
+            scanner_versions={"Toxicity": "1.0.0", "Bias": "1.0.0"},
+            llm_guard_version="0.3.16",
+            prompt_sample="Sample prompt...",
+            output_sample="Sample output...",
+        )
+        
+        assert record.record_id == "test-456"
+        assert record.timestamp == now
+        assert record.scan_type == "output"
+        assert record.feedback_type == "false_positive"
+        assert record.reported_scanners == ["Toxicity"]
+        assert record.user_comment == "This is not toxic"
+        assert record.prompt_hash == "abc123"
+        assert record.output_hash == "def456"
+        assert record.prompt_length == 50
+        assert record.output_length == 100
+        assert record.scanner_versions == {"Toxicity": "1.0.0", "Bias": "1.0.0"}
+        assert record.llm_guard_version == "0.3.16"
+        assert record.prompt_sample == "Sample prompt..."
+        assert record.output_sample == "Sample output..."
+    
+    def test_scan_type_values(self):
+        """Test that scan_type accepts valid literal values."""
+        prompt_record = FeedbackRecord(
+            record_id="test-1",
+            timestamp=datetime.now(),
+            scan_type="prompt",
+            scanner_results={},
+        )
+        assert prompt_record.scan_type == "prompt"
+        
+        output_record = FeedbackRecord(
+            record_id="test-2",
+            timestamp=datetime.now(),
+            scan_type="output",
+            scanner_results={},
+        )
+        assert output_record.scan_type == "output"
+    
+    def test_feedback_type_values(self):
+        """Test that feedback_type accepts valid literal values."""
+        for feedback_type in ["false_positive", "false_negative", "correct"]:
+            record = FeedbackRecord(
+                record_id=f"test-{feedback_type}",
+                timestamp=datetime.now(),
+                scan_type="prompt",
+                scanner_results={},
+                feedback_type=feedback_type,
+            )
+            assert record.feedback_type == feedback_type
+
+
+class TestFeedbackCollectorConfig:
+    """Tests for FeedbackCollectorConfig dataclass."""
+    
+    def test_default_instantiation(self):
+        """Test creating a config with all defaults."""
+        config = FeedbackCollectorConfig()
+        
+        assert config.enabled is False
+        assert config.privacy_level == 0
+        assert config.storage_backend == "memory"
+        assert config.storage_path is None
+        assert config.max_records == 1000
+        assert config.sampling_rate == 1.0
+        assert config.include_correct is False
+        assert config.auto_flush is False
+    
+    def test_custom_instantiation(self):
+        """Test creating a config with custom values."""
+        config = FeedbackCollectorConfig(
+            enabled=True,
+            privacy_level=2,
+            storage_backend="file",
+            storage_path="/tmp/feedback.json",
+            max_records=500,
+            sampling_rate=0.5,
+            include_correct=True,
+            auto_flush=True,
+        )
+        
+        assert config.enabled is True
+        assert config.privacy_level == 2
+        assert config.storage_backend == "file"
+        assert config.storage_path == "/tmp/feedback.json"
+        assert config.max_records == 500
+        assert config.sampling_rate == 0.5
+        assert config.include_correct is True
+        assert config.auto_flush is True
+    
+    def test_privacy_level_validation(self):
+        """Test that privacy_level is validated to be 0-3."""
+        # Valid values
+        for level in [0, 1, 2, 3]:
+            config = FeedbackCollectorConfig(privacy_level=level)
+            assert config.privacy_level == level
+        
+        # Invalid values
+        with pytest.raises(ValueError, match="privacy_level must be 0-3"):
+            FeedbackCollectorConfig(privacy_level=-1)
+        
+        with pytest.raises(ValueError, match="privacy_level must be 0-3"):
+            FeedbackCollectorConfig(privacy_level=4)
+    
+    def test_sampling_rate_validation(self):
+        """Test that sampling_rate is validated to be 0.0-1.0."""
+        # Valid values
+        for rate in [0.0, 0.5, 1.0]:
+            config = FeedbackCollectorConfig(sampling_rate=rate)
+            assert config.sampling_rate == rate
+        
+        # Invalid values
+        with pytest.raises(ValueError, match="sampling_rate must be 0.0-1.0"):
+            FeedbackCollectorConfig(sampling_rate=-0.1)
+        
+        with pytest.raises(ValueError, match="sampling_rate must be 0.0-1.0"):
+            FeedbackCollectorConfig(sampling_rate=1.5)
+    
+    def test_max_records_validation(self):
+        """Test that max_records must be >= 1."""
+        # Valid value
+        config = FeedbackCollectorConfig(max_records=1)
+        assert config.max_records == 1
+        
+        # Invalid value
+        with pytest.raises(ValueError, match="max_records must be >= 1"):
+            FeedbackCollectorConfig(max_records=0)
+        
+        with pytest.raises(ValueError, match="max_records must be >= 1"):
+            FeedbackCollectorConfig(max_records=-10)
+    
+    def test_file_backend_requires_path(self):
+        """Test that storage_backend='file' requires storage_path."""
+        # Valid: file backend with path
+        config = FeedbackCollectorConfig(
+            storage_backend="file",
+            storage_path="/tmp/feedback.json"
+        )
+        assert config.storage_backend == "file"
+        assert config.storage_path == "/tmp/feedback.json"
+        
+        # Invalid: file backend without path
+        with pytest.raises(ValueError, match="storage_path is required"):
+            FeedbackCollectorConfig(storage_backend="file")
+    
+    def test_auto_flush_requires_file_backend(self):
+        """Test that auto_flush requires storage_backend='file'."""
+        # Valid: auto_flush with file backend
+        config = FeedbackCollectorConfig(
+            storage_backend="file",
+            storage_path="/tmp/feedback.json",
+            auto_flush=True
+        )
+        assert config.auto_flush is True
+        
+        # Invalid: auto_flush with memory backend
+        with pytest.raises(ValueError, match="auto_flush requires storage_backend='file'"):
+            FeedbackCollectorConfig(
+                storage_backend="memory",
+                auto_flush=True
+            )
+    
+    def test_storage_backend_values(self):
+        """Test that storage_backend accepts valid literal values."""
+        for backend in ["memory", "file", "custom"]:
+            if backend == "file":
+                config = FeedbackCollectorConfig(
+                    storage_backend=backend,
+                    storage_path="/tmp/test.json"
+                )
+            else:
+                config = FeedbackCollectorConfig(storage_backend=backend)
+            assert config.storage_backend == backend

--- a/tests/feedback/test_model.py
+++ b/tests/feedback/test_model.py
@@ -14,7 +14,7 @@ from llm_guard.feedback.model import FeedbackCollectorConfig, FeedbackRecord
 
 class TestFeedbackRecord:
     """Tests for FeedbackRecord dataclass."""
-    
+
     def test_minimal_instantiation(self):
         """Test creating a FeedbackRecord with only required fields."""
         record = FeedbackRecord(
@@ -23,11 +23,11 @@ class TestFeedbackRecord:
             scan_type="prompt",
             scanner_results={"Toxicity": {"valid": True, "score": 0.1}},
         )
-        
+
         assert record.record_id == "test-123"
         assert record.scan_type == "prompt"
         assert record.scanner_results == {"Toxicity": {"valid": True, "score": 0.1}}
-        
+
         # Verify defaults
         assert record.feedback_type is None
         assert record.reported_scanners == []
@@ -40,7 +40,7 @@ class TestFeedbackRecord:
         assert record.llm_guard_version == ""
         assert record.prompt_sample is None
         assert record.output_sample is None
-    
+
     def test_full_instantiation(self):
         """Test creating a FeedbackRecord with all fields populated."""
         now = datetime.now()
@@ -64,7 +64,7 @@ class TestFeedbackRecord:
             prompt_sample="Sample prompt...",
             output_sample="Sample output...",
         )
-        
+
         assert record.record_id == "test-456"
         assert record.timestamp == now
         assert record.scan_type == "output"
@@ -79,7 +79,7 @@ class TestFeedbackRecord:
         assert record.llm_guard_version == "0.3.16"
         assert record.prompt_sample == "Sample prompt..."
         assert record.output_sample == "Sample output..."
-    
+
     def test_scan_type_values(self):
         """Test that scan_type accepts valid literal values."""
         prompt_record = FeedbackRecord(
@@ -89,7 +89,7 @@ class TestFeedbackRecord:
             scanner_results={},
         )
         assert prompt_record.scan_type == "prompt"
-        
+
         output_record = FeedbackRecord(
             record_id="test-2",
             timestamp=datetime.now(),
@@ -97,7 +97,7 @@ class TestFeedbackRecord:
             scanner_results={},
         )
         assert output_record.scan_type == "output"
-    
+
     def test_feedback_type_values(self):
         """Test that feedback_type accepts valid literal values."""
         for feedback_type in ["false_positive", "false_negative", "correct"]:
@@ -113,11 +113,11 @@ class TestFeedbackRecord:
 
 class TestFeedbackCollectorConfig:
     """Tests for FeedbackCollectorConfig dataclass."""
-    
+
     def test_default_instantiation(self):
         """Test creating a config with all defaults."""
         config = FeedbackCollectorConfig()
-        
+
         assert config.enabled is False
         assert config.privacy_level == 0
         assert config.storage_backend == "memory"
@@ -126,7 +126,7 @@ class TestFeedbackCollectorConfig:
         assert config.sampling_rate == 1.0
         assert config.include_correct is False
         assert config.auto_flush is False
-    
+
     def test_custom_instantiation(self):
         """Test creating a config with custom values."""
         config = FeedbackCollectorConfig(
@@ -139,7 +139,7 @@ class TestFeedbackCollectorConfig:
             include_correct=True,
             auto_flush=True,
         )
-        
+
         assert config.enabled is True
         assert config.privacy_level == 2
         assert config.storage_backend == "file"
@@ -148,86 +148,77 @@ class TestFeedbackCollectorConfig:
         assert config.sampling_rate == 0.5
         assert config.include_correct is True
         assert config.auto_flush is True
-    
+
     def test_privacy_level_validation(self):
         """Test that privacy_level is validated to be 0-3."""
         # Valid values
         for level in [0, 1, 2, 3]:
             config = FeedbackCollectorConfig(privacy_level=level)
             assert config.privacy_level == level
-        
+
         # Invalid values
         with pytest.raises(ValueError, match="privacy_level must be 0-3"):
             FeedbackCollectorConfig(privacy_level=-1)
-        
+
         with pytest.raises(ValueError, match="privacy_level must be 0-3"):
             FeedbackCollectorConfig(privacy_level=4)
-    
+
     def test_sampling_rate_validation(self):
         """Test that sampling_rate is validated to be 0.0-1.0."""
         # Valid values
         for rate in [0.0, 0.5, 1.0]:
             config = FeedbackCollectorConfig(sampling_rate=rate)
             assert config.sampling_rate == rate
-        
+
         # Invalid values
         with pytest.raises(ValueError, match="sampling_rate must be 0.0-1.0"):
             FeedbackCollectorConfig(sampling_rate=-0.1)
-        
+
         with pytest.raises(ValueError, match="sampling_rate must be 0.0-1.0"):
             FeedbackCollectorConfig(sampling_rate=1.5)
-    
+
     def test_max_records_validation(self):
         """Test that max_records must be >= 1."""
         # Valid value
         config = FeedbackCollectorConfig(max_records=1)
         assert config.max_records == 1
-        
+
         # Invalid value
         with pytest.raises(ValueError, match="max_records must be >= 1"):
             FeedbackCollectorConfig(max_records=0)
-        
+
         with pytest.raises(ValueError, match="max_records must be >= 1"):
             FeedbackCollectorConfig(max_records=-10)
-    
+
     def test_file_backend_requires_path(self):
         """Test that storage_backend='file' requires storage_path."""
         # Valid: file backend with path
-        config = FeedbackCollectorConfig(
-            storage_backend="file",
-            storage_path="/tmp/feedback.json"
-        )
+        config = FeedbackCollectorConfig(storage_backend="file", storage_path="/tmp/feedback.json")
         assert config.storage_backend == "file"
         assert config.storage_path == "/tmp/feedback.json"
-        
+
         # Invalid: file backend without path
         with pytest.raises(ValueError, match="storage_path is required"):
             FeedbackCollectorConfig(storage_backend="file")
-    
+
     def test_auto_flush_requires_file_backend(self):
         """Test that auto_flush requires storage_backend='file'."""
         # Valid: auto_flush with file backend
         config = FeedbackCollectorConfig(
-            storage_backend="file",
-            storage_path="/tmp/feedback.json",
-            auto_flush=True
+            storage_backend="file", storage_path="/tmp/feedback.json", auto_flush=True
         )
         assert config.auto_flush is True
-        
+
         # Invalid: auto_flush with memory backend
         with pytest.raises(ValueError, match="auto_flush requires storage_backend='file'"):
-            FeedbackCollectorConfig(
-                storage_backend="memory",
-                auto_flush=True
-            )
-    
+            FeedbackCollectorConfig(storage_backend="memory", auto_flush=True)
+
     def test_storage_backend_values(self):
         """Test that storage_backend accepts valid literal values."""
         for backend in ["memory", "file", "custom"]:
             if backend == "file":
                 config = FeedbackCollectorConfig(
-                    storage_backend=backend,
-                    storage_path="/tmp/test.json"
+                    storage_backend=backend, storage_path="/tmp/test.json"
                 )
             else:
                 config = FeedbackCollectorConfig(storage_backend=backend)

--- a/tests/feedback/test_storage.py
+++ b/tests/feedback/test_storage.py
@@ -17,50 +17,50 @@ from llm_guard.feedback.storage import FileStorage, InMemoryStorage, StorageBack
 
 class TestInMemoryStorage:
     """Tests for InMemoryStorage backend."""
-    
+
     def test_initialization(self):
         """Test creating an InMemoryStorage instance."""
         storage = InMemoryStorage(max_records=100)
         assert storage.list() == []
-    
+
     def test_initialization_validation(self):
         """Test that max_records is validated."""
         with pytest.raises(ValueError, match="max_records must be >= 1"):
             InMemoryStorage(max_records=0)
-        
+
         with pytest.raises(ValueError, match="max_records must be >= 1"):
             InMemoryStorage(max_records=-1)
-    
+
     def test_add_and_list(self):
         """Test adding records and listing them."""
         storage = InMemoryStorage()
-        
+
         record1 = FeedbackRecord(
             record_id="test-1",
             timestamp=datetime.now(),
             scan_type="prompt",
             scanner_results={"Toxicity": {"valid": True, "score": 0.1}},
         )
-        
+
         record2 = FeedbackRecord(
             record_id="test-2",
             timestamp=datetime.now(),
             scan_type="output",
             scanner_results={"Bias": {"valid": False, "score": 0.9}},
         )
-        
+
         storage.add(record1)
         storage.add(record2)
-        
+
         records = storage.list()
         assert len(records) == 2
         assert records[0].record_id == "test-1"
         assert records[1].record_id == "test-2"
-    
+
     def test_max_records_limit(self):
         """Test that storage respects max_records limit."""
         storage = InMemoryStorage(max_records=3)
-        
+
         # Add 5 records
         for i in range(5):
             record = FeedbackRecord(
@@ -70,18 +70,18 @@ class TestInMemoryStorage:
                 scanner_results={},
             )
             storage.add(record)
-        
+
         # Should only keep last 3
         records = storage.list()
         assert len(records) == 3
         assert records[0].record_id == "test-2"
         assert records[1].record_id == "test-3"
         assert records[2].record_id == "test-4"
-    
+
     def test_clear(self):
         """Test clearing all records."""
         storage = InMemoryStorage()
-        
+
         # Add some records
         for i in range(5):
             record = FeedbackRecord(
@@ -91,16 +91,16 @@ class TestInMemoryStorage:
                 scanner_results={},
             )
             storage.add(record)
-        
+
         # Clear and verify count
         count = storage.clear()
         assert count == 5
         assert storage.list() == []
-    
+
     def test_list_returns_copy(self):
         """Test that list() returns a copy, not the internal list."""
         storage = InMemoryStorage()
-        
+
         record = FeedbackRecord(
             record_id="test-1",
             timestamp=datetime.now(),
@@ -108,60 +108,60 @@ class TestInMemoryStorage:
             scanner_results={},
         )
         storage.add(record)
-        
+
         # Get list and modify it
         records = storage.list()
         records.clear()
-        
+
         # Original should be unchanged
         assert len(storage.list()) == 1
 
 
 class TestFileStorage:
     """Tests for FileStorage backend."""
-    
+
     def test_initialization_new_file(self):
         """Test creating FileStorage with a new file."""
         with tempfile.TemporaryDirectory() as tmpdir:
             file_path = Path(tmpdir) / "feedback.json"
             storage = FileStorage(str(file_path))
-            
+
             assert storage.list() == []
             assert not file_path.exists()  # File not created until first add
-    
+
     def test_initialization_validation(self):
         """Test that file_path is validated."""
         with pytest.raises(ValueError, match="file_path cannot be empty"):
             FileStorage("")
-    
+
     def test_add_and_save(self):
         """Test adding records and saving to file."""
         with tempfile.TemporaryDirectory() as tmpdir:
             file_path = Path(tmpdir) / "feedback.json"
             storage = FileStorage(str(file_path))
-            
+
             record = FeedbackRecord(
                 record_id="test-1",
                 timestamp=datetime.now(),
                 scan_type="prompt",
                 scanner_results={"Toxicity": {"valid": True, "score": 0.1}},
             )
-            
+
             storage.add(record)
-            
+
             # File should exist
             assert file_path.exists()
-            
+
             # Verify records
             records = storage.list()
             assert len(records) == 1
             assert records[0].record_id == "test-1"
-    
+
     def test_load_existing_file(self):
         """Test loading records from an existing file."""
         with tempfile.TemporaryDirectory() as tmpdir:
             file_path = Path(tmpdir) / "feedback.json"
-            
+
             # Create and populate storage
             storage1 = FileStorage(str(file_path))
             record = FeedbackRecord(
@@ -171,20 +171,20 @@ class TestFileStorage:
                 scanner_results={"Toxicity": {"valid": True, "score": 0.1}},
             )
             storage1.add(record)
-            
+
             # Create new storage instance (should load from file)
             storage2 = FileStorage(str(file_path))
             records = storage2.list()
-            
+
             assert len(records) == 1
             assert records[0].record_id == "test-1"
-    
+
     def test_clear_deletes_file(self):
         """Test that clear() deletes the file."""
         with tempfile.TemporaryDirectory() as tmpdir:
             file_path = Path(tmpdir) / "feedback.json"
             storage = FileStorage(str(file_path))
-            
+
             # Add a record
             record = FeedbackRecord(
                 record_id="test-1",
@@ -194,19 +194,19 @@ class TestFileStorage:
             )
             storage.add(record)
             assert file_path.exists()
-            
+
             # Clear
             count = storage.clear()
             assert count == 1
             assert not file_path.exists()
             assert storage.list() == []
-    
+
     def test_file_permissions(self):
         """Test that file is created with secure permissions (0600)."""
         with tempfile.TemporaryDirectory() as tmpdir:
             file_path = Path(tmpdir) / "feedback.json"
             storage = FileStorage(str(file_path))
-            
+
             record = FeedbackRecord(
                 record_id="test-1",
                 timestamp=datetime.now(),
@@ -214,34 +214,35 @@ class TestFileStorage:
                 scanner_results={},
             )
             storage.add(record)
-            
+
             # Check file permissions
             import stat
+
             file_stat = file_path.stat()
             file_mode = stat.S_IMODE(file_stat.st_mode)
-            
+
             # Should be 0600 (owner read/write only)
             assert file_mode == 0o600
-    
+
     def test_corrupted_file_handling(self):
         """Test that corrupted JSON files are handled gracefully."""
         with tempfile.TemporaryDirectory() as tmpdir:
             file_path = Path(tmpdir) / "feedback.json"
-            
+
             # Write corrupted JSON
-            with open(file_path, 'w') as f:
+            with open(file_path, "w") as f:
                 f.write("{ invalid json }")
-            
+
             # Should not crash, should start fresh
             storage = FileStorage(str(file_path))
             assert storage.list() == []
-    
+
     def test_parent_directory_creation(self):
         """Test that parent directories are created if needed."""
         with tempfile.TemporaryDirectory() as tmpdir:
             file_path = Path(tmpdir) / "subdir" / "feedback.json"
             storage = FileStorage(str(file_path))
-            
+
             record = FeedbackRecord(
                 record_id="test-1",
                 timestamp=datetime.now(),
@@ -249,16 +250,16 @@ class TestFileStorage:
                 scanner_results={},
             )
             storage.add(record)
-            
+
             assert file_path.exists()
             assert file_path.parent.exists()
-    
+
     def test_list_returns_copy(self):
         """Test that list() returns a copy, not the internal list."""
         with tempfile.TemporaryDirectory() as tmpdir:
             file_path = Path(tmpdir) / "feedback.json"
             storage = FileStorage(str(file_path))
-            
+
             record = FeedbackRecord(
                 record_id="test-1",
                 timestamp=datetime.now(),
@@ -266,24 +267,24 @@ class TestFileStorage:
                 scanner_results={},
             )
             storage.add(record)
-            
+
             # Get list and modify it
             records = storage.list()
             records.clear()
-            
+
             # Original should be unchanged
             assert len(storage.list()) == 1
 
 
 class TestStorageBackendInterface:
     """Tests for StorageBackend abstract interface."""
-    
+
     def test_interface_methods(self):
         """Test that StorageBackend defines the required interface."""
-        assert hasattr(StorageBackend, 'add')
-        assert hasattr(StorageBackend, 'list')
-        assert hasattr(StorageBackend, 'clear')
-    
+        assert hasattr(StorageBackend, "add")
+        assert hasattr(StorageBackend, "list")
+        assert hasattr(StorageBackend, "clear")
+
     def test_cannot_instantiate_abstract_class(self):
         """Test that StorageBackend cannot be instantiated directly."""
         with pytest.raises(TypeError):

--- a/tests/feedback/test_storage.py
+++ b/tests/feedback/test_storage.py
@@ -1,0 +1,290 @@
+"""
+Tests for feedback storage backends.
+
+These tests verify the storage abstraction and both implementations
+(InMemoryStorage and FileStorage).
+"""
+
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from llm_guard.feedback.model import FeedbackRecord
+from llm_guard.feedback.storage import FileStorage, InMemoryStorage, StorageBackend
+
+
+class TestInMemoryStorage:
+    """Tests for InMemoryStorage backend."""
+    
+    def test_initialization(self):
+        """Test creating an InMemoryStorage instance."""
+        storage = InMemoryStorage(max_records=100)
+        assert storage.list() == []
+    
+    def test_initialization_validation(self):
+        """Test that max_records is validated."""
+        with pytest.raises(ValueError, match="max_records must be >= 1"):
+            InMemoryStorage(max_records=0)
+        
+        with pytest.raises(ValueError, match="max_records must be >= 1"):
+            InMemoryStorage(max_records=-1)
+    
+    def test_add_and_list(self):
+        """Test adding records and listing them."""
+        storage = InMemoryStorage()
+        
+        record1 = FeedbackRecord(
+            record_id="test-1",
+            timestamp=datetime.now(),
+            scan_type="prompt",
+            scanner_results={"Toxicity": {"valid": True, "score": 0.1}},
+        )
+        
+        record2 = FeedbackRecord(
+            record_id="test-2",
+            timestamp=datetime.now(),
+            scan_type="output",
+            scanner_results={"Bias": {"valid": False, "score": 0.9}},
+        )
+        
+        storage.add(record1)
+        storage.add(record2)
+        
+        records = storage.list()
+        assert len(records) == 2
+        assert records[0].record_id == "test-1"
+        assert records[1].record_id == "test-2"
+    
+    def test_max_records_limit(self):
+        """Test that storage respects max_records limit."""
+        storage = InMemoryStorage(max_records=3)
+        
+        # Add 5 records
+        for i in range(5):
+            record = FeedbackRecord(
+                record_id=f"test-{i}",
+                timestamp=datetime.now(),
+                scan_type="prompt",
+                scanner_results={},
+            )
+            storage.add(record)
+        
+        # Should only keep last 3
+        records = storage.list()
+        assert len(records) == 3
+        assert records[0].record_id == "test-2"
+        assert records[1].record_id == "test-3"
+        assert records[2].record_id == "test-4"
+    
+    def test_clear(self):
+        """Test clearing all records."""
+        storage = InMemoryStorage()
+        
+        # Add some records
+        for i in range(5):
+            record = FeedbackRecord(
+                record_id=f"test-{i}",
+                timestamp=datetime.now(),
+                scan_type="prompt",
+                scanner_results={},
+            )
+            storage.add(record)
+        
+        # Clear and verify count
+        count = storage.clear()
+        assert count == 5
+        assert storage.list() == []
+    
+    def test_list_returns_copy(self):
+        """Test that list() returns a copy, not the internal list."""
+        storage = InMemoryStorage()
+        
+        record = FeedbackRecord(
+            record_id="test-1",
+            timestamp=datetime.now(),
+            scan_type="prompt",
+            scanner_results={},
+        )
+        storage.add(record)
+        
+        # Get list and modify it
+        records = storage.list()
+        records.clear()
+        
+        # Original should be unchanged
+        assert len(storage.list()) == 1
+
+
+class TestFileStorage:
+    """Tests for FileStorage backend."""
+    
+    def test_initialization_new_file(self):
+        """Test creating FileStorage with a new file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "feedback.json"
+            storage = FileStorage(str(file_path))
+            
+            assert storage.list() == []
+            assert not file_path.exists()  # File not created until first add
+    
+    def test_initialization_validation(self):
+        """Test that file_path is validated."""
+        with pytest.raises(ValueError, match="file_path cannot be empty"):
+            FileStorage("")
+    
+    def test_add_and_save(self):
+        """Test adding records and saving to file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "feedback.json"
+            storage = FileStorage(str(file_path))
+            
+            record = FeedbackRecord(
+                record_id="test-1",
+                timestamp=datetime.now(),
+                scan_type="prompt",
+                scanner_results={"Toxicity": {"valid": True, "score": 0.1}},
+            )
+            
+            storage.add(record)
+            
+            # File should exist
+            assert file_path.exists()
+            
+            # Verify records
+            records = storage.list()
+            assert len(records) == 1
+            assert records[0].record_id == "test-1"
+    
+    def test_load_existing_file(self):
+        """Test loading records from an existing file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "feedback.json"
+            
+            # Create and populate storage
+            storage1 = FileStorage(str(file_path))
+            record = FeedbackRecord(
+                record_id="test-1",
+                timestamp=datetime.now(),
+                scan_type="prompt",
+                scanner_results={"Toxicity": {"valid": True, "score": 0.1}},
+            )
+            storage1.add(record)
+            
+            # Create new storage instance (should load from file)
+            storage2 = FileStorage(str(file_path))
+            records = storage2.list()
+            
+            assert len(records) == 1
+            assert records[0].record_id == "test-1"
+    
+    def test_clear_deletes_file(self):
+        """Test that clear() deletes the file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "feedback.json"
+            storage = FileStorage(str(file_path))
+            
+            # Add a record
+            record = FeedbackRecord(
+                record_id="test-1",
+                timestamp=datetime.now(),
+                scan_type="prompt",
+                scanner_results={},
+            )
+            storage.add(record)
+            assert file_path.exists()
+            
+            # Clear
+            count = storage.clear()
+            assert count == 1
+            assert not file_path.exists()
+            assert storage.list() == []
+    
+    def test_file_permissions(self):
+        """Test that file is created with secure permissions (0600)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "feedback.json"
+            storage = FileStorage(str(file_path))
+            
+            record = FeedbackRecord(
+                record_id="test-1",
+                timestamp=datetime.now(),
+                scan_type="prompt",
+                scanner_results={},
+            )
+            storage.add(record)
+            
+            # Check file permissions
+            import stat
+            file_stat = file_path.stat()
+            file_mode = stat.S_IMODE(file_stat.st_mode)
+            
+            # Should be 0600 (owner read/write only)
+            assert file_mode == 0o600
+    
+    def test_corrupted_file_handling(self):
+        """Test that corrupted JSON files are handled gracefully."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "feedback.json"
+            
+            # Write corrupted JSON
+            with open(file_path, 'w') as f:
+                f.write("{ invalid json }")
+            
+            # Should not crash, should start fresh
+            storage = FileStorage(str(file_path))
+            assert storage.list() == []
+    
+    def test_parent_directory_creation(self):
+        """Test that parent directories are created if needed."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "subdir" / "feedback.json"
+            storage = FileStorage(str(file_path))
+            
+            record = FeedbackRecord(
+                record_id="test-1",
+                timestamp=datetime.now(),
+                scan_type="prompt",
+                scanner_results={},
+            )
+            storage.add(record)
+            
+            assert file_path.exists()
+            assert file_path.parent.exists()
+    
+    def test_list_returns_copy(self):
+        """Test that list() returns a copy, not the internal list."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "feedback.json"
+            storage = FileStorage(str(file_path))
+            
+            record = FeedbackRecord(
+                record_id="test-1",
+                timestamp=datetime.now(),
+                scan_type="prompt",
+                scanner_results={},
+            )
+            storage.add(record)
+            
+            # Get list and modify it
+            records = storage.list()
+            records.clear()
+            
+            # Original should be unchanged
+            assert len(storage.list()) == 1
+
+
+class TestStorageBackendInterface:
+    """Tests for StorageBackend abstract interface."""
+    
+    def test_interface_methods(self):
+        """Test that StorageBackend defines the required interface."""
+        assert hasattr(StorageBackend, 'add')
+        assert hasattr(StorageBackend, 'list')
+        assert hasattr(StorageBackend, 'clear')
+    
+    def test_cannot_instantiate_abstract_class(self):
+        """Test that StorageBackend cannot be instantiated directly."""
+        with pytest.raises(TypeError):
+            StorageBackend()

--- a/tests/feedback/test_wrapper.py
+++ b/tests/feedback/test_wrapper.py
@@ -1,0 +1,398 @@
+"""
+Tests for feedback wrapper functions.
+
+These tests verify that wrapper functions correctly integrate with scan_prompt
+and scan_output while maintaining exact same behavior and return values.
+"""
+
+import pytest
+
+from llm_guard.feedback import FeedbackCollector, FeedbackCollectorConfig
+from llm_guard.feedback.wrapper import (
+    scan_output_with_feedback,
+    scan_prompt_with_feedback,
+)
+
+
+# Mock scanner for testing
+class TestScanner:
+    """Mock input scanner for testing."""
+    
+    def __init__(self, valid: bool = True, score: float = 0.0):
+        self._valid = valid
+        self._score = score
+    
+    def scan(self, prompt: str) -> tuple[str, bool, float]:
+        """Mock scan method."""
+        return prompt, self._valid, self._score
+
+
+class Scanner1:
+    """Mock input scanner 1 for testing."""
+    
+    def __init__(self, valid: bool = True, score: float = 0.0):
+        self._valid = valid
+        self._score = score
+    
+    def scan(self, prompt: str) -> tuple[str, bool, float]:
+        """Mock scan method."""
+        return prompt, self._valid, self._score
+
+
+class Scanner2:
+    """Mock input scanner 2 for testing."""
+    
+    def __init__(self, valid: bool = True, score: float = 0.0):
+        self._valid = valid
+        self._score = score
+    
+    def scan(self, prompt: str) -> tuple[str, bool, float]:
+        """Mock scan method."""
+        return prompt, self._valid, self._score
+
+
+# Output scanner mocks
+class OutputTestScanner:
+    """Mock output scanner for testing."""
+    
+    def __init__(self, valid: bool = True, score: float = 0.0):
+        self._valid = valid
+        self._score = score
+    
+    def scan(self, prompt: str, output: str) -> tuple[str, bool, float]:
+        """Mock scan method."""
+        return output, self._valid, self._score
+
+
+class OutputScanner1:
+    """Mock output scanner 1 for testing."""
+    
+    def __init__(self, valid: bool = True, score: float = 0.0):
+        self._valid = valid
+        self._score = score
+    
+    def scan(self, prompt: str, output: str) -> tuple[str, bool, float]:
+        """Mock scan method."""
+        return output, self._valid, self._score
+
+
+class OutputScanner2:
+    """Mock output scanner 2 for testing."""
+    
+    def __init__(self, valid: bool = True, score: float = 0.0):
+        self._valid = valid
+        self._score = score
+    
+    def scan(self, prompt: str, output: str) -> tuple[str, bool, float]:
+        """Mock scan method."""
+        return output, self._valid, self._score
+
+
+class TestScanPromptWithFeedback:
+    """Tests for scan_prompt_with_feedback wrapper."""
+    
+    def test_without_collector(self):
+        """Test wrapper without collector behaves like scan_prompt."""
+        from llm_guard import scan_prompt
+        
+        scanners = [TestScanner(valid=True, score=0.1)]
+        prompt = "Hello world"
+        
+        # Call wrapper without collector
+        result_wrapper = scan_prompt_with_feedback(scanners, prompt, collector=None)
+        
+        # Call original scan_prompt
+        result_original = scan_prompt(scanners, prompt)
+        
+        # Results should be identical
+        assert result_wrapper == result_original
+    
+    def test_with_disabled_collector(self):
+        """Test wrapper with disabled collector doesn't record."""
+        config = FeedbackCollectorConfig(enabled=False)
+        collector = FeedbackCollector(config)
+        
+        scanners = [TestScanner(valid=False, score=0.9)]
+        prompt = "Test prompt"
+        
+        # Call wrapper
+        sanitized, valid, scores = scan_prompt_with_feedback(
+            scanners, prompt, collector=collector
+        )
+        
+        # Verify results
+        assert sanitized == prompt
+        assert valid == {"TestScanner": False}
+        assert scores == {"TestScanner": 0.9}
+        
+        # Verify nothing was recorded
+        assert len(collector.get_records()) == 0
+    
+    def test_with_enabled_collector(self):
+        """Test wrapper with enabled collector records scan."""
+        config = FeedbackCollectorConfig(enabled=True)
+        collector = FeedbackCollector(config)
+        
+        scanners = [TestScanner(valid=False, score=0.9)]
+        prompt = "Test prompt"
+        
+        # Call wrapper
+        sanitized, valid, scores = scan_prompt_with_feedback(
+            scanners, prompt, collector=collector
+        )
+        
+        # Verify results are correct
+        assert sanitized == prompt
+        assert valid == {"TestScanner": False}
+        assert scores == {"TestScanner": 0.9}
+        
+        # Verify scan was recorded
+        records = collector.get_records()
+        assert len(records) == 1
+        assert records[0].scan_type == "prompt"
+        assert records[0].scanner_results == {
+            "TestScanner": {"valid": False, "score": 0.9}
+        }
+    
+    def test_with_multiple_scanners(self):
+        """Test wrapper with multiple scanners."""
+        config = FeedbackCollectorConfig(enabled=True)
+        collector = FeedbackCollector(config)
+        
+        scanners = [
+            Scanner1(valid=True, score=0.1),
+            Scanner2(valid=False, score=0.8),
+        ]
+        prompt = "Test prompt"
+        
+        # Call wrapper
+        sanitized, valid, scores = scan_prompt_with_feedback(
+            scanners, prompt, collector=collector
+        )
+        
+        # Verify results
+        assert valid == {"Scanner1": True, "Scanner2": False}
+        assert scores == {"Scanner1": 0.1, "Scanner2": 0.8}
+        
+        # Verify scan was recorded with all scanners
+        records = collector.get_records()
+        assert len(records) == 1
+        assert "Scanner1" in records[0].scanner_results
+        assert "Scanner2" in records[0].scanner_results
+    
+    def test_with_fail_fast(self):
+        """Test wrapper passes through fail_fast parameter."""
+        config = FeedbackCollectorConfig(enabled=True)
+        collector = FeedbackCollector(config)
+        
+        scanners = [
+            Scanner1(valid=False, score=0.9),
+            Scanner2(valid=True, score=0.1),
+        ]
+        prompt = "Test prompt"
+        
+        # Call wrapper with fail_fast=True
+        sanitized, valid, scores = scan_prompt_with_feedback(
+            scanners, prompt, collector=collector, fail_fast=True
+        )
+        
+        # With fail_fast, only first scanner should run
+        assert "Scanner1" in valid
+        # Scanner2 might or might not be in results depending on scan_prompt implementation
+        
+        # Verify scan was recorded
+        assert len(collector.get_records()) == 1
+    
+    def test_return_type_matches_scan_prompt(self):
+        """Test that wrapper returns exact same type as scan_prompt."""
+        from llm_guard import scan_prompt
+        
+        scanners = [TestScanner(valid=True, score=0.5)]
+        prompt = "Test"
+        
+        result_wrapper = scan_prompt_with_feedback(scanners, prompt)
+        result_original = scan_prompt(scanners, prompt)
+        
+        # Check types match
+        assert type(result_wrapper) == type(result_original)
+        assert type(result_wrapper[0]) == type(result_original[0])
+        assert type(result_wrapper[1]) == type(result_original[1])
+        assert type(result_wrapper[2]) == type(result_original[2])
+
+
+class TestScanOutputWithFeedback:
+    """Tests for scan_output_with_feedback wrapper."""
+    
+    def test_without_collector(self):
+        """Test wrapper without collector behaves like scan_output."""
+        from llm_guard import scan_output
+        
+        scanners = [OutputTestScanner(valid=True, score=0.1)]
+        prompt = "What is AI?"
+        output = "AI is artificial intelligence"
+        
+        # Call wrapper without collector
+        result_wrapper = scan_output_with_feedback(
+            scanners, prompt, output, collector=None
+        )
+        
+        # Call original scan_output
+        result_original = scan_output(scanners, prompt, output)
+        
+        # Results should be identical
+        assert result_wrapper == result_original
+    
+    def test_with_disabled_collector(self):
+        """Test wrapper with disabled collector doesn't record."""
+        config = FeedbackCollectorConfig(enabled=False)
+        collector = FeedbackCollector(config)
+        
+        scanners = [OutputTestScanner(valid=False, score=0.9)]
+        prompt = "What is AI?"
+        output = "AI is artificial intelligence"
+        
+        # Call wrapper
+        sanitized, valid, scores = scan_output_with_feedback(
+            scanners, prompt, output, collector=collector
+        )
+        
+        # Verify results
+        assert sanitized == output
+        assert valid == {"OutputTestScanner": False}
+        assert scores == {"OutputTestScanner": 0.9}
+        
+        # Verify nothing was recorded
+        assert len(collector.get_records()) == 0
+    
+    def test_with_enabled_collector(self):
+        """Test wrapper with enabled collector records scan."""
+        config = FeedbackCollectorConfig(enabled=True)
+        collector = FeedbackCollector(config)
+        
+        scanners = [OutputTestScanner(valid=False, score=0.9)]
+        prompt = "What is AI?"
+        output = "AI is artificial intelligence"
+        
+        # Call wrapper
+        sanitized, valid, scores = scan_output_with_feedback(
+            scanners, prompt, output, collector=collector
+        )
+        
+        # Verify results are correct
+        assert sanitized == output
+        assert valid == {"OutputTestScanner": False}
+        assert scores == {"OutputTestScanner": 0.9}
+        
+        # Verify scan was recorded
+        records = collector.get_records()
+        assert len(records) == 1
+        assert records[0].scan_type == "output"
+        assert records[0].scanner_results == {
+            "OutputTestScanner": {"valid": False, "score": 0.9}
+        }
+        # Verify both prompt and output hashes exist
+        assert records[0].prompt_hash is not None
+        assert records[0].output_hash is not None
+    
+    def test_with_multiple_scanners(self):
+        """Test wrapper with multiple scanners."""
+        config = FeedbackCollectorConfig(enabled=True)
+        collector = FeedbackCollector(config)
+        
+        scanners = [
+            OutputScanner1(valid=True, score=0.1),
+            OutputScanner2(valid=False, score=0.8),
+        ]
+        prompt = "What is AI?"
+        output = "AI is artificial intelligence"
+        
+        # Call wrapper
+        sanitized, valid, scores = scan_output_with_feedback(
+            scanners, prompt, output, collector=collector
+        )
+        
+        # Verify results
+        assert valid == {"OutputScanner1": True, "OutputScanner2": False}
+        assert scores == {"OutputScanner1": 0.1, "OutputScanner2": 0.8}
+        
+        # Verify scan was recorded with all scanners
+        records = collector.get_records()
+        assert len(records) == 1
+        assert "OutputScanner1" in records[0].scanner_results
+        assert "OutputScanner2" in records[0].scanner_results
+    
+    def test_return_type_matches_scan_output(self):
+        """Test that wrapper returns exact same type as scan_output."""
+        from llm_guard import scan_output
+        
+        scanners = [OutputTestScanner(valid=True, score=0.5)]
+        prompt = "Test"
+        output = "Response"
+        
+        result_wrapper = scan_output_with_feedback(scanners, prompt, output)
+        result_original = scan_output(scanners, prompt, output)
+        
+        # Check types match
+        assert type(result_wrapper) == type(result_original)
+        assert type(result_wrapper[0]) == type(result_original[0])
+        assert type(result_wrapper[1]) == type(result_original[1])
+        assert type(result_wrapper[2]) == type(result_original[2])
+
+
+class TestWrapperIntegration:
+    """Integration tests for wrappers."""
+    
+    def test_prompt_and_output_workflow(self):
+        """Test complete workflow with both prompt and output scanning."""
+        config = FeedbackCollectorConfig(enabled=True, include_correct=True)
+        collector = FeedbackCollector(config)
+        
+        # Scan prompt
+        prompt_scanners = [TestScanner(valid=True, score=0.1)]
+        prompt = "What is AI?"
+        
+        sanitized_prompt, _, _ = scan_prompt_with_feedback(
+            prompt_scanners, prompt, collector=collector
+        )
+        
+        # Scan output
+        output_scanners = [OutputTestScanner(valid=True, score=0.2)]
+        output = "AI is artificial intelligence"
+        
+        sanitized_output, _, _ = scan_output_with_feedback(
+            output_scanners, sanitized_prompt, output, collector=collector
+        )
+        
+        # Verify both scans were recorded
+        records = collector.get_records()
+        assert len(records) == 2
+        
+        # Verify scan types
+        scan_types = {r.scan_type for r in records}
+        assert scan_types == {"prompt", "output"}
+    
+    def test_no_side_effects_on_core_scanning(self):
+        """Test that wrappers don't affect core scanning behavior."""
+        from llm_guard import scan_prompt
+        
+        scanners = [TestScanner(valid=False, score=0.9)]
+        prompt = "Test"
+        
+        # Get result from original function
+        original_result = scan_prompt(scanners, prompt)
+        
+        # Get result from wrapper (without collector)
+        wrapper_result = scan_prompt_with_feedback(scanners, prompt)
+        
+        # Results must be identical
+        assert wrapper_result == original_result
+        
+        # Get result from wrapper (with disabled collector)
+        config = FeedbackCollectorConfig(enabled=False)
+        collector = FeedbackCollector(config)
+        wrapper_result_disabled = scan_prompt_with_feedback(
+            scanners, prompt, collector=collector
+        )
+        
+        # Results must still be identical
+        assert wrapper_result_disabled == original_result

--- a/tests/feedback/test_wrapper.py
+++ b/tests/feedback/test_wrapper.py
@@ -5,23 +5,18 @@ These tests verify that wrapper functions correctly integrate with scan_prompt
 and scan_output while maintaining exact same behavior and return values.
 """
 
-import pytest
-
 from llm_guard.feedback import FeedbackCollector, FeedbackCollectorConfig
-from llm_guard.feedback.wrapper import (
-    scan_output_with_feedback,
-    scan_prompt_with_feedback,
-)
+from llm_guard.feedback.wrapper import scan_output_with_feedback, scan_prompt_with_feedback
 
 
 # Mock scanner for testing
 class TestScanner:
     """Mock input scanner for testing."""
-    
+
     def __init__(self, valid: bool = True, score: float = 0.0):
         self._valid = valid
         self._score = score
-    
+
     def scan(self, prompt: str) -> tuple[str, bool, float]:
         """Mock scan method."""
         return prompt, self._valid, self._score
@@ -29,11 +24,11 @@ class TestScanner:
 
 class Scanner1:
     """Mock input scanner 1 for testing."""
-    
+
     def __init__(self, valid: bool = True, score: float = 0.0):
         self._valid = valid
         self._score = score
-    
+
     def scan(self, prompt: str) -> tuple[str, bool, float]:
         """Mock scan method."""
         return prompt, self._valid, self._score
@@ -41,11 +36,11 @@ class Scanner1:
 
 class Scanner2:
     """Mock input scanner 2 for testing."""
-    
+
     def __init__(self, valid: bool = True, score: float = 0.0):
         self._valid = valid
         self._score = score
-    
+
     def scan(self, prompt: str) -> tuple[str, bool, float]:
         """Mock scan method."""
         return prompt, self._valid, self._score
@@ -54,11 +49,11 @@ class Scanner2:
 # Output scanner mocks
 class OutputTestScanner:
     """Mock output scanner for testing."""
-    
+
     def __init__(self, valid: bool = True, score: float = 0.0):
         self._valid = valid
         self._score = score
-    
+
     def scan(self, prompt: str, output: str) -> tuple[str, bool, float]:
         """Mock scan method."""
         return output, self._valid, self._score
@@ -66,11 +61,11 @@ class OutputTestScanner:
 
 class OutputScanner1:
     """Mock output scanner 1 for testing."""
-    
+
     def __init__(self, valid: bool = True, score: float = 0.0):
         self._valid = valid
         self._score = score
-    
+
     def scan(self, prompt: str, output: str) -> tuple[str, bool, float]:
         """Mock scan method."""
         return output, self._valid, self._score
@@ -78,11 +73,11 @@ class OutputScanner1:
 
 class OutputScanner2:
     """Mock output scanner 2 for testing."""
-    
+
     def __init__(self, valid: bool = True, score: float = 0.0):
         self._valid = valid
         self._score = score
-    
+
     def scan(self, prompt: str, output: str) -> tuple[str, bool, float]:
         """Mock scan method."""
         return output, self._valid, self._score
@@ -90,129 +85,130 @@ class OutputScanner2:
 
 class TestScanPromptWithFeedback:
     """Tests for scan_prompt_with_feedback wrapper."""
-    
+
     def test_without_collector(self):
         """Test wrapper without collector behaves like scan_prompt."""
         from llm_guard import scan_prompt
-        
+
         scanners = [TestScanner(valid=True, score=0.1)]
         prompt = "Hello world"
-        
+
         # Call wrapper without collector
         result_wrapper = scan_prompt_with_feedback(scanners, prompt, collector=None)
-        
+
         # Call original scan_prompt
-        result_original = scan_prompt(scanners, prompt)
-        
+        from typing import cast
+
+        from llm_guard.input_scanners.base import Scanner
+
+        result_original = scan_prompt(cast(list[Scanner], scanners), prompt)
+
         # Results should be identical
         assert result_wrapper == result_original
-    
+
     def test_with_disabled_collector(self):
         """Test wrapper with disabled collector doesn't record."""
         config = FeedbackCollectorConfig(enabled=False)
         collector = FeedbackCollector(config)
-        
+
         scanners = [TestScanner(valid=False, score=0.9)]
         prompt = "Test prompt"
-        
+
         # Call wrapper
-        sanitized, valid, scores = scan_prompt_with_feedback(
-            scanners, prompt, collector=collector
-        )
-        
+        sanitized, valid, scores = scan_prompt_with_feedback(scanners, prompt, collector=collector)
+
         # Verify results
         assert sanitized == prompt
         assert valid == {"TestScanner": False}
         assert scores == {"TestScanner": 0.9}
-        
+
         # Verify nothing was recorded
         assert len(collector.get_records()) == 0
-    
+
     def test_with_enabled_collector(self):
         """Test wrapper with enabled collector records scan."""
         config = FeedbackCollectorConfig(enabled=True)
         collector = FeedbackCollector(config)
-        
+
         scanners = [TestScanner(valid=False, score=0.9)]
         prompt = "Test prompt"
-        
+
         # Call wrapper
-        sanitized, valid, scores = scan_prompt_with_feedback(
-            scanners, prompt, collector=collector
-        )
-        
+        sanitized, valid, scores = scan_prompt_with_feedback(scanners, prompt, collector=collector)
+
         # Verify results are correct
         assert sanitized == prompt
         assert valid == {"TestScanner": False}
         assert scores == {"TestScanner": 0.9}
-        
+
         # Verify scan was recorded
         records = collector.get_records()
         assert len(records) == 1
         assert records[0].scan_type == "prompt"
-        assert records[0].scanner_results == {
-            "TestScanner": {"valid": False, "score": 0.9}
-        }
-    
+        assert records[0].scanner_results == {"TestScanner": {"valid": False, "score": 0.9}}
+
     def test_with_multiple_scanners(self):
         """Test wrapper with multiple scanners."""
         config = FeedbackCollectorConfig(enabled=True)
         collector = FeedbackCollector(config)
-        
+
         scanners = [
             Scanner1(valid=True, score=0.1),
             Scanner2(valid=False, score=0.8),
         ]
         prompt = "Test prompt"
-        
+
         # Call wrapper
-        sanitized, valid, scores = scan_prompt_with_feedback(
-            scanners, prompt, collector=collector
-        )
-        
+        sanitized, valid, scores = scan_prompt_with_feedback(scanners, prompt, collector=collector)
+
         # Verify results
         assert valid == {"Scanner1": True, "Scanner2": False}
         assert scores == {"Scanner1": 0.1, "Scanner2": 0.8}
-        
+
         # Verify scan was recorded with all scanners
         records = collector.get_records()
         assert len(records) == 1
         assert "Scanner1" in records[0].scanner_results
         assert "Scanner2" in records[0].scanner_results
-    
+
     def test_with_fail_fast(self):
         """Test wrapper passes through fail_fast parameter."""
         config = FeedbackCollectorConfig(enabled=True)
         collector = FeedbackCollector(config)
-        
+
         scanners = [
             Scanner1(valid=False, score=0.9),
             Scanner2(valid=True, score=0.1),
         ]
         prompt = "Test prompt"
-        
+
         # Call wrapper with fail_fast=True
         sanitized, valid, scores = scan_prompt_with_feedback(
             scanners, prompt, collector=collector, fail_fast=True
         )
-        
+
         # With fail_fast, only first scanner should run
         assert "Scanner1" in valid
         # Scanner2 might or might not be in results depending on scan_prompt implementation
-        
+
         # Verify scan was recorded
         assert len(collector.get_records()) == 1
-    
+
     def test_return_type_matches_scan_prompt(self):
         """Test that wrapper returns exact same type as scan_prompt."""
         from llm_guard import scan_prompt
-        
+
         scanners = [TestScanner(valid=True, score=0.5)]
         prompt = "Test"
-        
+
         result_wrapper = scan_prompt_with_feedback(scanners, prompt)
-        result_original = scan_prompt(scanners, prompt)
-        
+
+        from typing import cast
+
+        from llm_guard.input_scanners.base import Scanner
+
+        result_original = scan_prompt(cast(list[Scanner], scanners), prompt)
+
         # Check types match
         assert type(result_wrapper) == type(result_original)
         assert type(result_wrapper[0]) == type(result_original[0])
@@ -222,116 +218,121 @@ class TestScanPromptWithFeedback:
 
 class TestScanOutputWithFeedback:
     """Tests for scan_output_with_feedback wrapper."""
-    
+
     def test_without_collector(self):
         """Test wrapper without collector behaves like scan_output."""
         from llm_guard import scan_output
-        
+
         scanners = [OutputTestScanner(valid=True, score=0.1)]
         prompt = "What is AI?"
         output = "AI is artificial intelligence"
-        
+
         # Call wrapper without collector
-        result_wrapper = scan_output_with_feedback(
-            scanners, prompt, output, collector=None
-        )
-        
+        result_wrapper = scan_output_with_feedback(scanners, prompt, output, collector=None)
+
         # Call original scan_output
-        result_original = scan_output(scanners, prompt, output)
-        
+        from typing import cast
+
+        from llm_guard.output_scanners.base import Scanner as OutputScanner
+
+        result_original = scan_output(cast(list[OutputScanner], scanners), prompt, output)
+
         # Results should be identical
         assert result_wrapper == result_original
-    
+
     def test_with_disabled_collector(self):
         """Test wrapper with disabled collector doesn't record."""
         config = FeedbackCollectorConfig(enabled=False)
         collector = FeedbackCollector(config)
-        
+
         scanners = [OutputTestScanner(valid=False, score=0.9)]
         prompt = "What is AI?"
         output = "AI is artificial intelligence"
-        
+
         # Call wrapper
         sanitized, valid, scores = scan_output_with_feedback(
             scanners, prompt, output, collector=collector
         )
-        
+
         # Verify results
         assert sanitized == output
         assert valid == {"OutputTestScanner": False}
         assert scores == {"OutputTestScanner": 0.9}
-        
+
         # Verify nothing was recorded
         assert len(collector.get_records()) == 0
-    
+
     def test_with_enabled_collector(self):
         """Test wrapper with enabled collector records scan."""
         config = FeedbackCollectorConfig(enabled=True)
         collector = FeedbackCollector(config)
-        
+
         scanners = [OutputTestScanner(valid=False, score=0.9)]
         prompt = "What is AI?"
         output = "AI is artificial intelligence"
-        
+
         # Call wrapper
         sanitized, valid, scores = scan_output_with_feedback(
             scanners, prompt, output, collector=collector
         )
-        
+
         # Verify results are correct
         assert sanitized == output
         assert valid == {"OutputTestScanner": False}
         assert scores == {"OutputTestScanner": 0.9}
-        
+
         # Verify scan was recorded
         records = collector.get_records()
         assert len(records) == 1
         assert records[0].scan_type == "output"
-        assert records[0].scanner_results == {
-            "OutputTestScanner": {"valid": False, "score": 0.9}
-        }
+        assert records[0].scanner_results == {"OutputTestScanner": {"valid": False, "score": 0.9}}
         # Verify both prompt and output hashes exist
         assert records[0].prompt_hash is not None
         assert records[0].output_hash is not None
-    
+
     def test_with_multiple_scanners(self):
         """Test wrapper with multiple scanners."""
         config = FeedbackCollectorConfig(enabled=True)
         collector = FeedbackCollector(config)
-        
+
         scanners = [
             OutputScanner1(valid=True, score=0.1),
             OutputScanner2(valid=False, score=0.8),
         ]
         prompt = "What is AI?"
         output = "AI is artificial intelligence"
-        
+
         # Call wrapper
         sanitized, valid, scores = scan_output_with_feedback(
             scanners, prompt, output, collector=collector
         )
-        
+
         # Verify results
         assert valid == {"OutputScanner1": True, "OutputScanner2": False}
         assert scores == {"OutputScanner1": 0.1, "OutputScanner2": 0.8}
-        
+
         # Verify scan was recorded with all scanners
         records = collector.get_records()
         assert len(records) == 1
         assert "OutputScanner1" in records[0].scanner_results
         assert "OutputScanner2" in records[0].scanner_results
-    
+
     def test_return_type_matches_scan_output(self):
         """Test that wrapper returns exact same type as scan_output."""
         from llm_guard import scan_output
-        
+
         scanners = [OutputTestScanner(valid=True, score=0.5)]
         prompt = "Test"
         output = "Response"
-        
+
         result_wrapper = scan_output_with_feedback(scanners, prompt, output)
-        result_original = scan_output(scanners, prompt, output)
-        
+
+        from typing import cast
+
+        from llm_guard.output_scanners.base import Scanner as OutputScanner
+
+        result_original = scan_output(cast(list[OutputScanner], scanners), prompt, output)
+
         # Check types match
         assert type(result_wrapper) == type(result_original)
         assert type(result_wrapper[0]) == type(result_original[0])
@@ -341,58 +342,60 @@ class TestScanOutputWithFeedback:
 
 class TestWrapperIntegration:
     """Integration tests for wrappers."""
-    
+
     def test_prompt_and_output_workflow(self):
         """Test complete workflow with both prompt and output scanning."""
         config = FeedbackCollectorConfig(enabled=True, include_correct=True)
         collector = FeedbackCollector(config)
-        
+
         # Scan prompt
         prompt_scanners = [TestScanner(valid=True, score=0.1)]
         prompt = "What is AI?"
-        
+
         sanitized_prompt, _, _ = scan_prompt_with_feedback(
             prompt_scanners, prompt, collector=collector
         )
-        
+
         # Scan output
         output_scanners = [OutputTestScanner(valid=True, score=0.2)]
         output = "AI is artificial intelligence"
-        
+
         sanitized_output, _, _ = scan_output_with_feedback(
             output_scanners, sanitized_prompt, output, collector=collector
         )
-        
+
         # Verify both scans were recorded
         records = collector.get_records()
         assert len(records) == 2
-        
+
         # Verify scan types
         scan_types = {r.scan_type for r in records}
         assert scan_types == {"prompt", "output"}
-    
+
     def test_no_side_effects_on_core_scanning(self):
         """Test that wrappers don't affect core scanning behavior."""
         from llm_guard import scan_prompt
-        
+
         scanners = [TestScanner(valid=False, score=0.9)]
         prompt = "Test"
-        
+
         # Get result from original function
-        original_result = scan_prompt(scanners, prompt)
-        
+        from typing import cast
+
+        from llm_guard.input_scanners.base import Scanner
+
+        original_result = scan_prompt(cast(list[Scanner], scanners), prompt)
+
         # Get result from wrapper (without collector)
         wrapper_result = scan_prompt_with_feedback(scanners, prompt)
-        
+
         # Results must be identical
         assert wrapper_result == original_result
-        
+
         # Get result from wrapper (with disabled collector)
         config = FeedbackCollectorConfig(enabled=False)
         collector = FeedbackCollector(config)
-        wrapper_result_disabled = scan_prompt_with_feedback(
-            scanners, prompt, collector=collector
-        )
-        
+        wrapper_result_disabled = scan_prompt_with_feedback(scanners, prompt, collector=collector)
+
         # Results must still be identical
         assert wrapper_result_disabled == original_result


### PR DESCRIPTION
## Change Description

This PR adds an **optional, privacy first feedback extension** to `llm guard` that allows users to record false positives and false negatives from scanner results.

The implementation is fully **additive and opt-in**, and **does not modify any existing scanning logic or APIs**.

### Key characteristics
- Privacy first feedback data models (no raw text stored by default)
- Feedback collector with minimal pluggable storage backends:
  - In-memory (default)
  - Local JSON file
- Thin, explicit wrapper functions for opt-in integration with:
  - `scan_prompt`
  - `scan_output`
- Zero behavior change when the feature is unused
- No network calls, background processing, or side effects in core scanning

The feature is implemented as an isolated extension under `llm_guard.feedback`.

---

## Issue reference

This PR does not directly fix an existing issue.  
It introduces an **optional extension** intended to help users provide structured feedback on scanner decisions.

(If helpful, I’m happy to link this to a new issue or discussion.)

---

## Checklist

- [x] I have reviewed the contribution guidelines
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required  

> Documentation and examples were intentionally deferred to keep this PR focused on code and tests.  
> I’m happy to add user facing docs or examples in a follow up PR if this approach seems acceptable.
