### PR TITLE
feat: add ToolCallAudit output scanner for agent tool call validation

### DIFF
--- a/docs/output_scanners/tool_call_audit.md
+++ b/docs/output_scanners/tool_call_audit.md
@@ -1,0 +1,55 @@
+# Tool Call Audit Scanner
+
+This scanner validates tool and function calls in LLM output. It checks that only permitted functions are invoked and that arguments do not contain injection attacks.
+
+## Attack scenario
+
+Agentic AI systems let LLMs invoke external tools: reading files, querying databases, calling APIs. If the LLM is manipulated through prompt injection or jailbreaking, it can generate tool calls that invoke dangerous functions, pass malicious payloads through arguments, or exfiltrate data through unexpected endpoints.
+
+## How it works
+
+The scanner is entirely rule based (no model downloads required) and performs two checks:
+
+1. **Function name validation**: Checks the function name against a configurable allowlist or denylist.
+
+2. **Argument injection detection**: Scans all argument values (including nested objects) for known injection patterns:
+    - Shell injection: `; rm -rf`, `$(command)`, backticks, pipe to shell
+    - Path traversal: `../`, `/etc/passwd`, `/proc/self/`
+    - SQL injection: `' OR 1=1`, `; DROP TABLE`, `UNION SELECT`
+    - SSRF: cloud metadata endpoints, localhost, private IP ranges
+
+Supports multiple tool call formats: `{"name": ..., "arguments": ...}`, OpenAI's `{"function": {"name": ..., "arguments": ...}}`, and `{"tool_calls": [...]}` wrappers.
+
+If the output contains no tool calls, the scanner passes it through as valid.
+
+## Usage
+
+```python
+from llm_guard.output_scanners import ToolCallAudit
+
+# Allowlist mode: only these functions are permitted
+scanner = ToolCallAudit(
+    allowed_functions=["read_file", "write_file", "search_db"],
+)
+sanitized_output, is_valid, risk_score = scanner.scan(prompt, model_output)
+
+# Denylist mode: block specific dangerous functions
+scanner = ToolCallAudit(
+    denied_functions=["exec_command", "delete_file", "shell"],
+)
+sanitized_output, is_valid, risk_score = scanner.scan(prompt, model_output)
+
+# Injection detection only (no function name filtering)
+scanner = ToolCallAudit(detect_injection=True)
+sanitized_output, is_valid, risk_score = scanner.scan(prompt, model_output)
+```
+
+## Configuration
+
+| Parameter            | Type        | Default | Description                                                      |
+|----------------------|-------------|---------|------------------------------------------------------------------|
+| `allowed_functions`  | `list[str]` | `None`  | Allowlist of permitted function names. Exclusive with denylist    |
+| `denied_functions`   | `list[str]` | `None`  | Denylist of blocked function names. Exclusive with allowlist      |
+| `detect_injection`   | `bool`      | `True`  | Whether to scan argument values for injection patterns           |
+| `redact`             | `bool`      | `False` | Whether to replace blocked tool calls with `[TOOL CALL REDACTED]`|
+| `threshold`          | `float`     | `0.5`   | Risk threshold for flagging                                      |

--- a/llm_guard/output_scanners/__init__.py
+++ b/llm_guard/output_scanners/__init__.py
@@ -20,6 +20,7 @@ from .regex import Regex
 from .relevance import Relevance
 from .sensitive import Sensitive
 from .sentiment import Sentiment
+from .tool_call_audit import ToolCallAudit
 from .toxicity import Toxicity
 from .url_reachabitlity import URLReachability
 from .util import get_scanner_by_name
@@ -46,6 +47,7 @@ __all__ = [
     "Relevance",
     "Sensitive",
     "Sentiment",
+    "ToolCallAudit",
     "Toxicity",
     "URLReachability",
     "get_scanner_by_name",

--- a/llm_guard/output_scanners/tool_call_audit.py
+++ b/llm_guard/output_scanners/tool_call_audit.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import json
+import re
+
+from llm_guard.util import get_logger
+
+from .base import Scanner
+
+LOGGER = get_logger()
+
+_INJECTION_PATTERNS: list[tuple[re.Pattern, str]] = [
+    # Shell injection
+    (
+        re.compile(r";\s*(?:rm|cat|curl|wget|bash|sh|chmod|chown|kill|dd|nc)\b", re.I),
+        "shell injection",
+    ),
+    (re.compile(r"\$\([^)]+\)", re.I), "shell injection"),
+    (re.compile(r"`[^`]+`", re.I), "shell injection"),
+    (re.compile(r"\|\s*(?:sh|bash|zsh|cmd|powershell)\b", re.I), "shell injection"),
+    (re.compile(r"&&\s*(?:rm|curl|wget|bash|sh|chmod|dd|nc)\b", re.I), "shell injection"),
+    (re.compile(r"\brm\s+-[rRf]+\b", re.I), "shell injection"),
+    # Path traversal
+    (re.compile(r"\.\./", re.I), "path traversal"),
+    (re.compile(r"/etc/(?:passwd|shadow|hosts|sudoers)", re.I), "path traversal"),
+    (re.compile(r"/proc/self/", re.I), "path traversal"),
+    # SQL injection
+    (re.compile(r";\s*(?:DROP|DELETE|INSERT|UPDATE|ALTER|CREATE)\s", re.I), "SQL injection"),
+    (re.compile(r"UNION\s+(?:ALL\s+)?SELECT\s", re.I), "SQL injection"),
+    # SSRF
+    (re.compile(r"https?://169\.254\.169\.254", re.I), "SSRF"),
+    (re.compile(r"https?://metadata\.google\.internal", re.I), "SSRF"),
+    (re.compile(r"https?://(?:localhost|127\.0\.0\.1|0\.0\.0\.0)", re.I), "SSRF"),
+    (re.compile(r"https?://10\.\d{1,3}\.\d{1,3}\.\d{1,3}", re.I), "SSRF"),
+    (re.compile(r"https?://172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}", re.I), "SSRF"),
+    (re.compile(r"https?://192\.168\.\d{1,3}\.\d{1,3}", re.I), "SSRF"),
+]
+
+
+def _try_parse_json(text: str) -> dict | list | None:
+    try:
+        return json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+def _is_tool_call(obj: dict) -> bool:
+    if "function" in obj and isinstance(obj["function"], dict):
+        return "name" in obj["function"]
+    if "name" in obj and ("arguments" in obj or "args" in obj):
+        return True
+    return isinstance(obj.get("function"), str) and ("arguments" in obj or "args" in obj)
+
+
+def _get_function_name(tc: dict) -> str:
+    if "function" in tc and isinstance(tc["function"], dict):
+        return tc["function"].get("name", "")
+    if "name" in tc:
+        return tc["name"]
+    return tc.get("function", "") if isinstance(tc.get("function"), str) else ""
+
+
+def _get_arguments(tc: dict) -> dict:
+    if "function" in tc and isinstance(tc["function"], dict):
+        args = tc["function"].get("arguments", {})
+    else:
+        args = tc.get("arguments", tc.get("args", {}))
+
+    if isinstance(args, str):
+        parsed = _try_parse_json(args)
+        return parsed if isinstance(parsed, dict) else {}
+    return args if isinstance(args, dict) else {}
+
+
+def _flatten_values(obj: dict) -> list[str]:
+    values = []
+    for v in obj.values():
+        if isinstance(v, str):
+            values.append(v)
+        elif isinstance(v, dict):
+            values.extend(_flatten_values(v))
+        elif isinstance(v, list):
+            for item in v:
+                if isinstance(item, str):
+                    values.append(item)
+                elif isinstance(item, dict):
+                    values.extend(_flatten_values(item))
+    return values
+
+
+def _extract_tool_calls(output: str) -> list[dict]:
+    parsed = _try_parse_json(output.strip())
+    if parsed is not None:
+        if isinstance(parsed, list):
+            return [item for item in parsed if isinstance(item, dict) and _is_tool_call(item)]
+        if isinstance(parsed, dict):
+            if _is_tool_call(parsed):
+                return [parsed]
+            if "tool_calls" in parsed and isinstance(parsed["tool_calls"], list):
+                return [
+                    item
+                    for item in parsed["tool_calls"]
+                    if isinstance(item, dict) and _is_tool_call(item)
+                ]
+
+    # Fallback: find JSON objects embedded in text
+    tool_calls = []
+    depth, start = 0, None
+    for i, ch in enumerate(output):
+        if ch == "{":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0 and start is not None:
+                obj = _try_parse_json(output[start : i + 1])
+                if isinstance(obj, dict) and _is_tool_call(obj):
+                    tool_calls.append(obj)
+                start = None
+    return tool_calls
+
+
+def _check_injection(values: list[str]) -> tuple[bool, str]:
+    for pattern, label in _INJECTION_PATTERNS:
+        for value in values:
+            if pattern.search(value):
+                return True, label
+    return False, ""
+
+
+class ToolCallAudit(Scanner):
+    """
+    A scanner that validates tool/function calls in LLM output.
+
+    Checks function names against an allowlist or denylist and scans argument values
+    for injection attacks (shell injection, path traversal, SQL injection, SSRF).
+    """
+
+    def __init__(
+        self,
+        *,
+        allowed_functions: list[str] | None = None,
+        denied_functions: list[str] | None = None,
+        detect_injection: bool = True,
+        redact: bool = False,
+        threshold: float = 0.5,
+    ) -> None:
+        if allowed_functions and denied_functions:
+            raise ValueError("Provide either allowed_functions or denied_functions, not both.")
+
+        self._allowed = {f.lower() for f in allowed_functions} if allowed_functions else None
+        self._denied = {f.lower() for f in denied_functions} if denied_functions else None
+        self._detect_injection = detect_injection
+        self._redact = redact
+        self._threshold = threshold
+
+    def scan(self, prompt: str, output: str) -> tuple[str, bool, float]:
+        if output.strip() == "":
+            return output, True, -1.0
+
+        tool_calls = _extract_tool_calls(output)
+        if not tool_calls:
+            return output, True, -1.0
+
+        LOGGER.debug("Found tool calls in output", count=len(tool_calls))
+        violations = []
+
+        for tc in tool_calls:
+            name = _get_function_name(tc).lower()
+
+            if self._allowed is not None and name not in self._allowed:
+                LOGGER.warning("Function not in allowlist", function=name)
+                violations.append(tc)
+                continue
+
+            if self._denied is not None and name in self._denied:
+                LOGGER.warning("Function in denylist", function=name)
+                violations.append(tc)
+                continue
+
+            if self._detect_injection:
+                args = _get_arguments(tc)
+                if args:
+                    found, label = _check_injection(_flatten_values(args))
+                    if found:
+                        LOGGER.warning("Injection detected in arguments", function=name, type=label)
+                        violations.append(tc)
+
+        if not violations:
+            return output, True, -1.0
+
+        sanitized_output = output
+        if self._redact:
+            for tc in violations:
+                sanitized_output = sanitized_output.replace(
+                    json.dumps(tc, default=str), "[TOOL CALL REDACTED]"
+                )
+
+        score = round(len(violations) / len(tool_calls), 1)
+        return sanitized_output, False, score

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -149,6 +149,7 @@ nav:
       - Relevance: output_scanners/relevance.md
       - Sensitive: output_scanners/sensitive.md
       - Sentiment: output_scanners/sentiment.md
+      - Tool Call Audit: output_scanners/tool_call_audit.md
       - Toxicity: output_scanners/toxicity.md
       - URL Reachability: output_scanners/url_reachability.md
   - API:

--- a/tests/output_scanners/test_tool_call_audit.py
+++ b/tests/output_scanners/test_tool_call_audit.py
@@ -1,0 +1,107 @@
+import pytest
+
+from llm_guard.output_scanners.tool_call_audit import ToolCallAudit
+
+
+@pytest.mark.parametrize(
+    "prompt,output,expected_valid,expected_score",
+    [
+        # Plain text, no tool call
+        ("What is the weather?", "The weather is sunny today.", True, -1.0),
+        # Empty output
+        ("Do something", "", True, -1.0),
+        # Valid tool call
+        ("Read the file", '{"name": "read_file", "arguments": {"path": "doc.txt"}}', True, -1.0),
+        # Function not in allowlist
+        ("Delete it", '{"name": "exec_command", "arguments": {"cmd": "ls"}}', False, 1.0),
+        # Shell injection
+        ("List files", '{"name": "read_file", "arguments": {"path": "; rm -rf /"}}', False, 1.0),
+        # Path traversal
+        (
+            "Read file",
+            '{"name": "read_file", "arguments": {"path": "../../../etc/passwd"}}',
+            False,
+            1.0,
+        ),
+        # SQL injection
+        (
+            "Search",
+            '{"name": "search_db", "arguments": {"query": "; DROP TABLE users"}}',
+            False,
+            1.0,
+        ),
+        # SSRF
+        (
+            "Fetch",
+            '{"name": "read_file", "arguments": {"url": "http://169.254.169.254/meta"}}',
+            False,
+            1.0,
+        ),
+    ],
+)
+def test_scan_with_allowlist(prompt, output, expected_valid, expected_score):
+    scanner = ToolCallAudit(allowed_functions=["read_file", "write_file", "search_db"])
+    sanitized_output, valid, score = scanner.scan(prompt, output)
+    assert valid == expected_valid
+    assert score == expected_score
+
+
+def test_scan_with_denylist():
+    scanner = ToolCallAudit(denied_functions=["exec_command", "delete_file"])
+    _, valid, _ = scanner.scan("", '{"name": "exec_command", "arguments": {"cmd": "ls"}}')
+    assert valid is False
+
+    _, valid, _ = scanner.scan("", '{"name": "read_file", "arguments": {"path": "doc.txt"}}')
+    assert valid is True
+
+
+def test_openai_tool_calls_format():
+    scanner = ToolCallAudit(allowed_functions=["get_weather"])
+    output = '{"tool_calls": [{"function": {"name": "get_weather", "arguments": "{\\"city\\": \\"NYC\\"}"}}]}'
+    _, valid, score = scanner.scan("", output)
+    assert valid is True
+    assert score == -1.0
+
+
+def test_tool_call_embedded_in_text():
+    scanner = ToolCallAudit(allowed_functions=["read_file"])
+    output = 'I will call: {"name": "read_file", "arguments": {"path": "test.txt"}} now.'
+    _, valid, _ = scanner.scan("", output)
+    assert valid is True
+
+
+def test_multiple_tool_calls_mixed():
+    scanner = ToolCallAudit(allowed_functions=["read_file", "write_file"])
+    output = '[{"name": "read_file", "arguments": {"path": "ok.txt"}}, {"name": "exec_cmd", "arguments": {"cmd": "ls"}}]'
+    _, valid, score = scanner.scan("", output)
+    assert valid is False
+    assert score == 0.5
+
+
+def test_nested_injection():
+    scanner = ToolCallAudit(allowed_functions=["query"])
+    output = '{"name": "query", "arguments": {"filter": {"value": "../../etc/shadow"}}}'
+    _, valid, _ = scanner.scan("", output)
+    assert valid is False
+
+
+def test_redact():
+    scanner = ToolCallAudit(allowed_functions=["read_file"], redact=True)
+    output = '{"name": "exec_command", "arguments": {"cmd": "ls"}}'
+    sanitized, valid, _ = scanner.scan("", output)
+    assert valid is False
+    assert "[TOOL CALL REDACTED]" in sanitized
+
+
+def test_both_allowlist_and_denylist_raises():
+    with pytest.raises(ValueError):
+        ToolCallAudit(allowed_functions=["read_file"], denied_functions=["exec_command"])
+
+
+def test_injection_only_mode():
+    scanner = ToolCallAudit(detect_injection=True)
+    _, valid, _ = scanner.scan("", '{"name": "any_func", "arguments": {"data": "hello"}}')
+    assert valid is True
+
+    _, valid, _ = scanner.scan("", '{"name": "any_func", "arguments": {"cmd": "; rm -rf /"}}')
+    assert valid is False


### PR DESCRIPTION
## Change Description

Adds a `ToolCallAudit` output scanner that validates LLM generated tool/function calls. Two checks:

1. **Function name validation**: allowlist or denylist of permitted function names
2. **Argument injection detection**: shell injection, path traversal, SQL injection, SSRF

Rule based, no model downloads, no new dependencies. Supports OpenAI `tool_calls` format and simple `{"name": ..., "arguments": ...}` objects.

## Issue reference

N/A (new feature)

## Checklist

- [x] I have reviewed the [contribution guidelines](../CONTRIBUTING.md)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required