### PR TITLE
fix: mitigate path traversal and replace dangerous asserts

### DIFF
--- a/llm_guard/input_scanners/anonymize_helpers/transformers_recognizer.py
+++ b/llm_guard/input_scanners/anonymize_helpers/transformers_recognizer.py
@@ -208,8 +208,10 @@ class TransformersRecognizer(EntityRecognizer):
         :return: List of entity predictions on the word level
         :rtype: List[dict]
         """
-        assert self.pipeline is not None
-        assert self.pipeline.tokenizer is not None
+        if self.pipeline is None:
+            raise RuntimeError("NER pipeline is not initialized")
+        if self.pipeline.tokenizer is None:
+            raise RuntimeError("NER pipeline tokenizer is not initialized")
 
         model_max_length = self.pipeline.tokenizer.model_max_length
         # calculate inputs based on the text
@@ -233,7 +235,11 @@ class TransformersRecognizer(EntityRecognizer):
                 chunk_text = text[chunk.start : chunk.end]
                 chunk_preds = self.pipeline(chunk_text)
 
-                assert isinstance(chunk_preds, list)
+                if not isinstance(chunk_preds, list):
+                    raise RuntimeError(
+                        f"NER pipeline returned {type(chunk_preds).__name__} "
+                        "instead of list for text chunk"
+                    )
 
                 # align indexes to match the original text - add to each position the value of chunk_start
                 aligned_predictions: list[dict[str, Any]] = []

--- a/llm_guard/input_scanners/ban_competitors.py
+++ b/llm_guard/input_scanners/ban_competitors.py
@@ -79,7 +79,10 @@ class BanCompetitors(Scanner):
         is_detected = False
         text_replace_builder = TextReplaceBuilder(original_text=prompt)
         entities = self._get_ner_results_for_text(prompt)
-        assert isinstance(entities, list)
+        if not isinstance(entities, list):
+            raise RuntimeError(
+                f"NER pipeline returned {type(entities).__name__} instead of list"
+            )
         entities = sorted(entities, key=lambda x: x["end"], reverse=True)
 
         for entity in entities:
@@ -128,8 +131,10 @@ class BanCompetitors(Scanner):
         :return: List of entity predictions on the word level
         :rtype: List[dict]
         """
-        assert self._ner_pipeline is not None
-        assert self._ner_pipeline.tokenizer is not None
+        if self._ner_pipeline is None:
+            raise RuntimeError("NER pipeline is not initialized")
+        if self._ner_pipeline.tokenizer is None:
+            raise RuntimeError("NER pipeline tokenizer is not initialized")
 
         model_max_length = self._ner_pipeline.tokenizer.model_max_length
         # calculate inputs based on the text
@@ -159,7 +164,11 @@ class BanCompetitors(Scanner):
                 chunk_text = text[chunk.start : chunk.end]
                 chunk_preds = self._ner_pipeline(chunk_text)
 
-                assert isinstance(chunk_preds, list)
+                if not isinstance(chunk_preds, list):
+                    raise RuntimeError(
+                        f"NER pipeline returned {type(chunk_preds).__name__} "
+                        "instead of list for text chunk"
+                    )
 
                 # align indexes to match the original text - add to each position the value of chunk_start
                 aligned_predictions: list[dict[str, Any]] = []

--- a/llm_guard/output_scanners/relevance.py
+++ b/llm_guard/output_scanners/relevance.py
@@ -90,7 +90,11 @@ class Relevance(Scanner):
                     ),
                 ),
             )
-            assert model.onnx_path is not None
+            if model.onnx_path is None:
+                raise ValueError(
+                    "ONNX path must be provided when use_onnx=True. "
+                    "Set model.onnx_path or disable ONNX."
+                )
             self._model = optimum_onnxruntime.ORTModelForFeatureExtraction.from_pretrained(
                 model.onnx_path,
                 export=False,
@@ -141,7 +145,11 @@ class Relevance(Scanner):
         with torch.no_grad():
             last_hidden_state = self._model(**inputs, return_dict=True).last_hidden_state
             embeddings = self.pooling(last_hidden_state, inputs["attention_mask"])
-            assert embeddings is not None
+            if embeddings is None:
+                raise RuntimeError(
+                    f"Pooling method '{self.pooling_method}' returned None. "
+                    "Supported methods: 'cls', 'mean'."
+                )
             if self.normalize_embeddings:
                 embeddings = torch.nn.functional.normalize(embeddings, dim=-1)
 

--- a/llm_guard_api/app/config.py
+++ b/llm_guard_api/app/config.py
@@ -67,14 +67,37 @@ def _path_constructor(_loader: Any, node: Any):
     return _var_matcher.sub(replace_fn, node.value)
 
 
+_ALLOWED_CONFIG_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _resolve_safe_path(filename: str) -> str:
+    """Resolve and validate that a config file path is within the allowed directory.
+
+    Raises:
+        ValueError: If the resolved path escapes the allowed config directory.
+    """
+    resolved = os.path.abspath(filename)
+    allowed = os.path.abspath(_ALLOWED_CONFIG_DIR)
+    if not resolved.startswith(allowed + os.sep) and resolved != allowed:
+        raise ValueError(
+            f"Config file path '{filename}' resolves outside the allowed "
+            f"directory '{allowed}'"
+        )
+    return resolved
+
+
 def load_yaml(filename: str) -> dict:
+    safe_path = _resolve_safe_path(filename)
     yaml.add_implicit_resolver("!envvar", _tag_matcher, None, yaml.SafeLoader)
     yaml.add_constructor("!envvar", _path_constructor, yaml.SafeLoader)
     try:
-        with open(filename, "r") as f:
+        with open(safe_path, "r") as f:
             return yaml.safe_load(f.read())
     except (FileNotFoundError, PermissionError, yaml.YAMLError) as exc:
         LOGGER.error("Error loading YAML file", exception=exc)
+        return dict()
+    except ValueError as exc:
+        LOGGER.error("Rejected config file path", exception=exc)
         return dict()
 
 


### PR DESCRIPTION
## Summary

Addresses #323 — fixes two classes of security vulnerabilities:

### 1. Path Traversal in Config Loader (`llm_guard_api/app/config.py`)
- Added `_resolve_safe_path()` that resolves and validates file paths against an allowed config directory before opening
- Prevents attackers from loading arbitrary YAML files via path traversal (e.g., `../../etc/passwd`)

### 2. Dangerous `assert` Statements (4 files)
Replaced all `assert` statements with explicit `ValueError`/`RuntimeError` checks in:
- `llm_guard/output_scanners/relevance.py` — ONNX path validation + embeddings pooling check
- `llm_guard/input_scanners/ban_competitors.py` — NER pipeline initialization + return type checks
- `llm_guard/input_scanners/anonymize_helpers/transformers_recognizer.py` — same pattern

`assert` statements are stripped when Python runs in optimized mode (`python -O`), silently disabling critical validation. The replacements ensure checks always run.

## Changes
- 4 files changed, 56 insertions, 10 deletions
- Zero behavioral changes for correct inputs
- All error messages include actionable context

## Test Plan
- [ ] Verify `load_yaml()` rejects paths outside allowed directory
- [ ] Verify scanners raise `RuntimeError` (not `AssertionError`) when pipeline is `None`
- [ ] Confirm existing tests pass unchanged
- [ ] Run with `python -O` to verify checks still execute