### PR TITLE
docs: Corrected the default threshold value for ban_topics

### DIFF
--- a/llm_guard/input_scanners/ban_topics.py
+++ b/llm_guard/input_scanners/ban_topics.py
@@ -110,7 +110,7 @@ class BanTopics(Scanner):
 
         Parameters:
             topics (Sequence[str]): List of topics to ban.
-            threshold (float, optional): Threshold to determine if a topic is present in the prompt. Default is 0.75.
+            threshold (float, optional): Threshold to determine if a topic is present in the prompt. Default is 0.6.
             model (Model, optional): Model to use for zero-shot classification. Default is roberta-base-c-v2.
             use_onnx (bool, optional): Whether to use ONNX for inference. Default is False.
 


### PR DESCRIPTION
## Doc strings for the object BanTopics

I have updated the **doc strings of the BanTopics** object (to be specific I matched the value to that in the args)

## Issue reference

This PR fixes issue #XX

## Checklist

- [x] I have reviewed the [contribution guidelines](../CONTRIBUTING.md)
- [ ] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
