### PR TITLE
fix(secrets): sort secrets by position descending to prevent redaction offset errors with multiple secrets

### DIFF
--- a/llm_guard/input_scanners/secrets.py
+++ b/llm_guard/input_scanners/secrets.py
@@ -471,25 +471,33 @@ class Secrets(Scanner):
             secrets.scan_file(str(temp_file.name))
 
         secret_types = []
-        text_replace_builder = TextReplaceBuilder(original_text=prompt)
+        # Collect all secrets with their positions before any replacement.
+        # Sort by start position descending so that right-to-left processing
+        # keeps earlier positions stable after each substitution.
+        found_secrets = []
         for file in secrets.files:
             for found_secret in secrets[file]:
                 if found_secret.secret_value is None:
                     continue
+                start = prompt.find(found_secret.secret_value)
+                if start == -1:
+                    continue
+                found_secrets.append((start, found_secret))
 
-                secret_types.append(found_secret.type)
+        found_secrets.sort(key=lambda x: x[0], reverse=True)
 
-                character_start_index = prompt.find(found_secret.secret_value, None, None)
-                character_end_index = character_start_index + len(str(found_secret.secret_value))
-                secret_value = text_replace_builder.get_text_in_position(
-                    character_start_index, character_end_index
-                )
-
-                text_replace_builder.replace_text_get_insertion_index(
-                    self.redact_value(secret_value, self._redact_mode),
-                    character_start_index,
-                    character_end_index,
-                )
+        text_replace_builder = TextReplaceBuilder(original_text=prompt)
+        for character_start_index, found_secret in found_secrets:
+            secret_types.append(found_secret.type)
+            character_end_index = character_start_index + len(str(found_secret.secret_value))
+            secret_value = text_replace_builder.get_text_in_position(
+                character_start_index, character_end_index
+            )
+            text_replace_builder.replace_text_get_insertion_index(
+                self.redact_value(secret_value, self._redact_mode),
+                character_start_index,
+                character_end_index,
+            )
 
         os.remove(temp_file.name)
 


### PR DESCRIPTION
## Summary

Fixes #305

When a prompt contains more than one secret and `redact_mode=all`, the second (and subsequent) secrets were not correctly redacted — sometimes remaining in plaintext or getting duplicated in the output.

## Root Cause

`TextReplaceBuilder` maintains an internal offset as replacements are applied. After the first secret is replaced, the internal state shifts, so the original character positions of later secrets no longer align correctly. The original code called `prompt.find(secret_value)` to get positions from the unmodified string, but then passed those positions into a builder that had already been modified by the first substitution.

## Fix

Collect all secrets and their start positions from the **original prompt** upfront, before any replacements are made. Sort them in **descending order** by start position (right-to-left). Processing from right to left ensures that each replacement never shifts the positions of secrets that haven't been processed yet.

## Before / After

**Before:**
```
Input:  "... sk-OPENAI_KEY_HERE and ghp_GITHUB_TOKEN_HERE"
Output: "... ****** and ghp_GITHUB_TOKEN_HERE****** and ghp_GITHUB_TOKEN_HERE"
```

**After:**
```
Input:  "... sk-OPENAI_KEY_HERE and ghp_GITHUB_TOKEN_HERE"
Output: "... ****** and ******"
```

## Testing

The fix is minimal (sort + collect positions before applying replacements). No existing behavior changes for single-secret prompts.