### PR TITLE
fix: ensure top_k is set in MaliciousURLs pipeline_kwargs

### DIFF
--- a/llm_guard/output_scanners/malicious_urls.py
+++ b/llm_guard/output_scanners/malicious_urls.py
@@ -57,6 +57,9 @@ class MaliciousURLs(Scanner):
         if model is None:
             model = DEFAULT_MODEL
 
+        if "top_k" not in model.pipeline_kwargs:
+            model.pipeline_kwargs["top_k"] = None
+
         tf_tokenizer, tf_model = get_tokenizer_and_model_for_classification(
             model=model,
             use_onnx=use_onnx,


### PR DESCRIPTION
## Summary

- Fixes `TypeError: string indices must be integers, not 'str'` when using a custom `Model` with `MaliciousURLs` scanner
- When `top_k` is not in `pipeline_kwargs`, the HuggingFace pipeline returns a single dict instead of a list of dicts, causing the scan loop to iterate over string keys
- Adds `top_k=None` to `pipeline_kwargs` if not already present, ensuring consistent list-of-dicts output format

## Test plan

- [x] Default `MaliciousURLs()` still works (already has `top_k=None`)
- [x] Custom `Model` without `top_k` no longer crashes
- [x] Custom `Model` with explicit `top_k` value is not overridden

Fixes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)