### PR TITLE
feat(input-scanners): add MaliciousURLs input scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ pip install llm-guard
 - [Gibberish](https://protectai.github.io/llm-guard/input_scanners/gibberish/)
 - [InvisibleText](https://protectai.github.io/llm-guard/input_scanners/invisible_text/)
 - [Language](https://protectai.github.io/llm-guard/input_scanners/language/)
+- [MaliciousURLs](https://protectai.github.io/llm-guard/input_scanners/malicious_urls/)
 - [PromptInjection](https://protectai.github.io/llm-guard/input_scanners/prompt_injection/)
 - [Regex](https://protectai.github.io/llm-guard/input_scanners/regex/)
 - [Secrets](https://protectai.github.io/llm-guard/input_scanners/secrets/)

--- a/docs/input_scanners/malicious_urls.md
+++ b/docs/input_scanners/malicious_urls.md
@@ -1,0 +1,40 @@
+# Malicious URLs Scanner
+
+This scanner detects URLs in the prompt and analyzes them for harmfulness, such as detecting phishing websites.
+
+## Attack scenario
+
+User-supplied prompts can contain malicious URLs, whether typed directly by an end user or smuggled in through a
+prompt-injection or social-engineering payload. If such a URL reaches the model, a downstream tool, a browsing agent,
+or another user, it can lead to phishing, malware delivery, or defacement. Scanning the prompt before it is processed
+lets the application reject or flag these URLs early.
+
+## How it works
+
+The scanner uses
+the [DunnBC22/codebert-base-Malicious_URLs](https://huggingface.co/DunnBC22/codebert-base-Malicious_URLs) model from
+HuggingFace to evaluate the security of each URL found in the prompt.
+
+The model provides a score between 0 and 1 for a URL being malware. This score is then compared against a pre-set
+threshold to determine if the website is malicious. A score above the threshold suggests a malware link.
+
+## Usage
+
+```python
+from llm_guard.input_scanners import MaliciousURLs
+
+scanner = MaliciousURLs(threshold=0.7)
+sanitized_prompt, is_valid, risk_score = scanner.scan(prompt)
+```
+
+## Optimization Strategies
+
+[Read more](../tutorials/optimization.md)
+
+## Benchmarks
+
+Run the following script:
+
+```sh
+python benchmarks/run.py input MaliciousURLs
+```

--- a/llm_guard/input_scanners/__init__.py
+++ b/llm_guard/input_scanners/__init__.py
@@ -10,6 +10,7 @@ from .emotion_detection import EmotionDetection
 from .gibberish import Gibberish
 from .invisible_text import InvisibleText
 from .language import Language
+from .malicious_urls import MaliciousURLs
 from .prompt_injection import PromptInjection
 from .regex import Regex
 from .secrets import Secrets
@@ -29,6 +30,7 @@ __all__ = [
     "Gibberish",
     "InvisibleText",
     "Language",
+    "MaliciousURLs",
     "PromptInjection",
     "Regex",
     "Secrets",

--- a/llm_guard/input_scanners/malicious_urls.py
+++ b/llm_guard/input_scanners/malicious_urls.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from llm_guard.model import Model
+from llm_guard.transformers_helpers import get_tokenizer_and_model_for_classification, pipeline
+from llm_guard.util import calculate_risk_score, extract_urls, get_logger
+
+from .base import Scanner
+
+LOGGER = get_logger()
+DEFAULT_MODEL = Model(
+    path="DunnBC22/codebert-base-Malicious_URLs",
+    revision="1221284b2495a4182cdb521be9d755de56e66899",
+    onnx_path="ProtectAI/codebert-base-Malicious_URLs-onnx",
+    onnx_revision="7bc4fa926eeae5e752d0790cc42faa24eb32fa64",
+    pipeline_kwargs={
+        "top_k": None,
+        "return_token_type_ids": False,
+        "max_length": 128,
+        "truncation": True,
+    },
+)
+
+_malicious_labels = [
+    "defacement",
+    "phishing",
+    "malware",
+]
+
+
+class MaliciousURLs(Scanner):
+    """
+    This scanner is used to scan and detect malicious URLs in the prompt.
+
+    Users can embed malicious URLs in their prompts, for example as part of a
+    prompt-injection or social-engineering payload intended to reach the model,
+    a downstream tool, or another user. Using the
+    "DunnBC22/codebert-base-Malicious_URLs" model from HuggingFace, this class
+    classifies URLs as either malicious or benign before the prompt is processed.
+    """
+
+    def __init__(
+        self,
+        *,
+        model: Model | None = None,
+        threshold: float = 0.5,
+        use_onnx: bool = False,
+    ) -> None:
+        """
+        Initializes an instance of the MaliciousURLs class.
+
+        Parameters:
+            model (Model, optional): The model to use for malicious URL detection.
+            threshold (float): The threshold used to determine if the website is malicious. Defaults to 0.5.
+            use_onnx (bool): Whether to use the ONNX version of the model. Defaults to False.
+        """
+
+        self._threshold = threshold
+
+        if model is None:
+            model = DEFAULT_MODEL
+
+        tf_tokenizer, tf_model = get_tokenizer_and_model_for_classification(
+            model=model,
+            use_onnx=use_onnx,
+        )
+
+        self._classifier = pipeline(
+            task="text-classification",
+            model=tf_model,
+            tokenizer=tf_tokenizer,
+            **model.pipeline_kwargs,
+        )
+
+    def scan(self, prompt: str) -> tuple[str, bool, float]:
+        if prompt.strip() == "":
+            return prompt, True, -1.0
+
+        urls = extract_urls(prompt)
+        if len(urls) == 0:
+            return prompt, True, -1.0
+
+        LOGGER.debug("Found URLs in the prompt", len=len(urls))
+
+        highest_malicious_score = 0.0
+        results = self._classifier(urls)
+        for url, result in zip(urls, results):
+            malicious_scores = [
+                item["score"] for item in result if item["label"] in _malicious_labels
+            ]
+            highest_malicious_score = max(malicious_scores)
+            if highest_malicious_score > self._threshold:
+                LOGGER.warning(
+                    "Detected malware URL",
+                    url=url,
+                    highest_score=highest_malicious_score,
+                )
+
+                return (
+                    prompt,
+                    False,
+                    calculate_risk_score(highest_malicious_score, self._threshold),
+                )
+
+        LOGGER.debug(
+            "No malware URLs in the prompt",
+            results=results,
+            highest_score=highest_malicious_score,
+        )
+
+        return (
+            prompt,
+            True,
+            calculate_risk_score(highest_malicious_score, self._threshold),
+        )

--- a/llm_guard/input_scanners/util.py
+++ b/llm_guard/input_scanners/util.py
@@ -10,6 +10,7 @@ from .code import Code
 from .gibberish import Gibberish
 from .invisible_text import InvisibleText
 from .language import Language
+from .malicious_urls import MaliciousURLs
 from .prompt_injection import PromptInjection
 from .regex import Regex
 from .secrets import Secrets
@@ -58,6 +59,9 @@ def get_scanner_by_name(scanner_name: str, scanner_config: dict | None = None) -
 
     if scanner_name == "Language":
         return Language(**scanner_config)
+
+    if scanner_name == "MaliciousURLs":
+        return MaliciousURLs(**scanner_config)
 
     if scanner_name == "PromptInjection":
         return PromptInjection(**scanner_config)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,6 +124,7 @@ nav:
       - Gibberish: input_scanners/gibberish.md
       - Invisible Text: input_scanners/invisible_text.md
       - Language: input_scanners/language.md
+      - Malicious URLs: input_scanners/malicious_urls.md
       - Prompt Injection: input_scanners/prompt_injection.md
       - Regex: input_scanners/regex.md
       - Secrets: input_scanners/secrets.md

--- a/tests/input_scanners/test_malicious_urls.py
+++ b/tests/input_scanners/test_malicious_urls.py
@@ -1,0 +1,41 @@
+import pytest
+
+from llm_guard.input_scanners.malicious_urls import MaliciousURLs
+
+
+@pytest.mark.parametrize(
+    "prompt,expected_valid,expected_score",
+    [
+        (
+            "Check out https://google.com/.",
+            True,
+            -0.5,
+        ),  # Good prompt
+        (
+            "Look at http://socialsocietyedu.com/components/com_wa/config.bin and http://facebuk.co/signup.html",
+            False,
+            0.5,
+        ),  # Bad prompt
+        (
+            "See https://google.com/ and https://facebook.com/.",
+            True,
+            -0.6,
+        ),  # Good prompt with multiple URLs
+        (
+            "No URLs here at all.",
+            True,
+            -1.0,
+        ),  # No URLs
+        (
+            "",
+            True,
+            -1.0,
+        ),  # Empty prompt
+    ],
+)
+def test_scan(prompt, expected_valid, expected_score):
+    scanner = MaliciousURLs()
+    sanitized_prompt, valid, score = scanner.scan(prompt)
+    assert sanitized_prompt == prompt
+    assert valid == expected_valid
+    assert score == expected_score


### PR DESCRIPTION
# Add MaliciousURLs input scanner

## Summary

Adds an input-side `MaliciousURLs` scanner, mirroring the existing output scanner. Most scanners in llm-guard exist on both the input and output side (Toxicity, Code, Sentiment, Regex, Ban*, Gibberish, Language); `MaliciousURLs` only existed on the output side. This fills that gap.

## Motivation

Prompts can carry malicious URLs, whether typed by an end user or smuggled in through a prompt-injection or social-engineering payload, intended to reach the model, a downstream tool, a browsing agent, or another user. Scanning the prompt before it is processed lets the application reject or flag these URLs early, rather than only catching them in the model's output.

## Implementation

Reuses ProtectAI's own `DunnBC22/codebert-base-Malicious_URLs` model and the existing `extract_urls` util. The implementation is the output scanner adapted to the input `scan(self, prompt) -> tuple[str, bool, float]` signature (scanning the prompt instead of the output).

## Files

- `llm_guard/input_scanners/malicious_urls.py` (new) — the scanner
- `tests/input_scanners/test_malicious_urls.py` (new) — unit tests
- `llm_guard/input_scanners/__init__.py` — export the scanner
- `llm_guard/input_scanners/util.py` — register in `get_scanner_by_name`
- `docs/input_scanners/malicious_urls.md` (new) — docs page
- `mkdocs.yml` — docs nav entry
- `README.md` — input scanner list entry

## Testing

- `ruff check` and `ruff format --check` pass (pinned ruff 0.11.10)
- `pytest tests/input_scanners/test_malicious_urls.py` (downloads the model on first run)

The test reuses the same URL fixtures and expected scores as the output scanner's test, since the model classifies the extracted URLs identically regardless of which side they came from.
