### PR TITLE
fix(output-scanners): correct status-code list typing in URLReachability

### DIFF
--- a/llm_guard/output_scanners/url_reachabitlity.py
+++ b/llm_guard/output_scanners/url_reachabitlity.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import cast
+
 import requests
 
 from llm_guard.util import extract_urls, get_logger
@@ -21,11 +23,17 @@ class URLReachability(Scanner):
             timeout: The timeout in seconds for the HTTP requests.
         """
         if success_status_codes is None:
-            success_status_codes = [
-                requests.codes.ok,
-                requests.codes.created,
-                requests.codes.accepted,
-            ]
+            # requests.codes.* is typed as `int | None` by the stubs, so the
+            # literal list is inferred as list[int | None]; these are always
+            # concrete status codes, so cast to the declared list[int].
+            success_status_codes = cast(
+                "list[int]",
+                [
+                    requests.codes.ok,
+                    requests.codes.created,
+                    requests.codes.accepted,
+                ],
+            )
 
         self._success_status_codes = success_status_codes
         self._timeout = timeout


### PR DESCRIPTION
## Summary

Fixes two pyright errors in `llm_guard/output_scanners/url_reachabitlity.py` that currently fail the Lint CI job (`pre-commit run --all-files`).

## The errors

```
url_reachabitlity.py:24:36 - error: Type "list[int | None]" is not assignable to declared type "list[int] | None" (reportAssignmentType)
url_reachabitlity.py:39:20 - error: Operator "in" not supported for types "int" and "list[int] | None" (reportOperatorIssue)
```

## Cause

The `requests` type stubs type `requests.codes.*` as `int | None`. The default `success_status_codes` list literal is therefore inferred as `list[int | None]`, which is not assignable to the parameter's declared `list[int] | None`. That in turn makes `self._success_status_codes` typed as `list[int] | None`, which breaks the `in` membership check in `is_reachable`.

These attributes are always concrete HTTP status codes at runtime (200/201/202), so the values are never actually `None`.

## Fix

Cast the default list to `list[int]`, preserving the existing `requests.codes.*` named constants. No behavioral change.

## Notes

- pyright is unpinned in the project and CI is currently on 1.1.410, which surfaces this; older pyright versions did not flag it.
- Alternative considered: replacing `requests.codes.ok/created/accepted` with the integer literals `200, 201, 202`. Kept the named constants for readability; happy to switch to literals if preferred.

## Testing

- `pyright llm_guard/output_scanners/url_reachabitlity.py` → 0 errors, 0 warnings
- `ruff check` and `ruff format --check` pass (pinned ruff 0.11.10)
